### PR TITLE
Unified parallel download

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ python-dateutil
 psycopg2-binary
 multiprocess
 zeep
+tqdm

--- a/soap_api/main.py
+++ b/soap_api/main.py
@@ -18,6 +18,9 @@ __author__ = "Ludee; christian-rli"
 __issue__ = "https://github.com/OpenEnergyPlatform/examples/issues/52"
 __version__ = "v0.9.0"
 
+import datetime
+import time
+
 from soap_api.config import setup_logger
 from soap_api.mastr_general_download import get_mastr_time, get_mastr_time_auth, get_daily_contingent
 # from soap_api.mastr_power_unit_download import download_parallel_power_unit, download_power_unit
@@ -27,15 +30,13 @@ from soap_api.mastr_general_download import get_mastr_time, get_mastr_time_auth,
 # from soap_api.mastr_hydro_process import make_hydro
 # from soap_api.mastr_biomass_download import setup_power_unit_biomass, download_unit_biomass, download_unit_biomass_eeg
 # from soap_api.mastr_biomass_process import make_biomass
-from soap_api.mastr_solar_download import setup_power_unit_solar, download_parallel_unit_solar, read_power_unit_solar, read_unit_solar
+from soap_api.mastr_solar_download import download_parallel_unit_solar
 # from soap_api.mastr_solar_process import make_solar
 # from soap_api.mastr_storage_units_download import download_unit_storage, download_parallel_unit_storage
 # from soap_api.mastr_nuclear_download import setup_power_unit_nuclear, download_unit_nuclear
 # from soap_api.mastr_nuclear_process import make_nuclear
 # # from soap_api.mastr_wind_processing import do_wind
 from soap_api.utils import is_time_blacklisted, fname_solar_unit, fname_power_unit_solar
-import datetime
-import time
 
 
 if __name__ == "__main__":
@@ -85,17 +86,7 @@ if __name__ == "__main__":
 
     """Solar"""
 
-    # TODO: Do this as long as there are remaining generators
-    while True:
-        if not is_time_blacklisted(datetime.datetime.now().time()):
-            a = read_power_unit_solar(fname_power_unit_solar)['EinheitMastrNummer'] # all generators
-            b = read_unit_solar(fname_solar_unit)['EinheitMastrNummer'] # already downloaded generators
-            c = a[~a.isin(b)] # remaining generators
-            download_parallel_unit_solar(c)
-        else:
-            log.info('Current time of day in blacklist. Idle.')
-            time.sleep(60)
-
+    download_parallel_unit_solar()
     # setup_power_unit_solar()
     # ''' DEFAULT PARAMS: start_from=0, n_entries=1, parallelism=12 '''
     # download_parallel_unit_solar(

--- a/soap_api/main.py
+++ b/soap_api/main.py
@@ -20,19 +20,21 @@ __version__ = "v0.9.0"
 
 from soap_api.config import setup_logger
 from soap_api.mastr_general_download import get_mastr_time, get_mastr_time_auth, get_daily_contingent
-from soap_api.mastr_power_unit_download import download_parallel_power_unit, download_power_unit
-from soap_api.mastr_wind_download import setup_power_unit_wind, download_unit_wind, download_unit_wind_eeg, download_unit_wind_permit
-from soap_api.mastr_wind_process import make_wind
-from soap_api.mastr_hydro_download import setup_power_unit_hydro, download_unit_hydro, download_unit_hydro_eeg
-from soap_api.mastr_hydro_process import make_hydro
-from soap_api.mastr_biomass_download import setup_power_unit_biomass, download_unit_biomass, download_unit_biomass_eeg
-from soap_api.mastr_biomass_process import make_biomass
-from soap_api.mastr_solar_download import setup_power_unit_solar, download_unit_solar, download_parallel_unit_solar, download_unit_solar_eeg, download_parallel_unit_solar_eeg
-from soap_api.mastr_solar_process import make_solar
-from soap_api.mastr_storage_units_download import download_unit_storage, download_parallel_unit_storage
-from soap_api.mastr_nuclear_download import setup_power_unit_nuclear, download_unit_nuclear
-from soap_api.mastr_nuclear_process import make_nuclear
-# from soap_api.mastr_wind_processing import do_wind
+# from soap_api.mastr_power_unit_download import download_parallel_power_unit, download_power_unit
+# from soap_api.mastr_wind_download import setup_power_unit_wind, download_unit_wind, download_unit_wind_eeg, download_unit_wind_permit
+# from soap_api.mastr_wind_process import make_wind
+# from soap_api.mastr_hydro_download import setup_power_unit_hydro, download_unit_hydro, download_unit_hydro_eeg
+# from soap_api.mastr_hydro_process import make_hydro
+# from soap_api.mastr_biomass_download import setup_power_unit_biomass, download_unit_biomass, download_unit_biomass_eeg
+# from soap_api.mastr_biomass_process import make_biomass
+from soap_api.mastr_solar_download import setup_power_unit_solar, download_parallel_unit_solar, read_power_unit_solar, read_unit_solar
+# from soap_api.mastr_solar_process import make_solar
+# from soap_api.mastr_storage_units_download import download_unit_storage, download_parallel_unit_storage
+# from soap_api.mastr_nuclear_download import setup_power_unit_nuclear, download_unit_nuclear
+# from soap_api.mastr_nuclear_process import make_nuclear
+# # from soap_api.mastr_wind_processing import do_wind
+from soap_api.utils import is_time_blacklisted, fname_solar_unit, fname_power_unit_solar
+import datetime
 import time
 
 
@@ -82,16 +84,28 @@ if __name__ == "__main__":
     # make_biomass()
 
     """Solar"""
+
+    # TODO: Do this as long as there are remaining generators
+    while True:
+        if not is_time_blacklisted(datetime.datetime.now().time()):
+            a = read_power_unit_solar(fname_power_unit_solar)['EinheitMastrNummer'] # all generators
+            b = read_unit_solar(fname_solar_unit)['EinheitMastrNummer'] # already downloaded generators
+            c = a[~a.isin(b)] # remaining generators
+            download_parallel_unit_solar(c)
+        else:
+            log.info('Current time of day in blacklist. Idle.')
+            time.sleep(60)
+
     # setup_power_unit_solar()
     # ''' DEFAULT PARAMS: start_from=0, n_entries=1, parallelism=12 '''
     # download_parallel_unit_solar(
     #     start_from=0,
     #     n_entries=1,
     #     parallelism=12)
-    download_parallel_unit_solar_eeg(
-       start_from=0,
-       n_entries=1,
-       parallelism=12)
+    # download_parallel_unit_solar_eeg(
+    #    start_from=0,
+    #    n_entries=1,
+    #    parallelism=12)
     # make_solar()
 
     """ Storages"""

--- a/soap_api/mastr_power_unit_download.py
+++ b/soap_api/mastr_power_unit_download.py
@@ -76,11 +76,12 @@ def get_power_unit(start_from, wind=False, datum='1900-01-01 00:00:00.00000', li
         s = serialize_object(c)
         power_unit = pd.DataFrame(s['Einheiten'])
         power_unit.index.names = ['lid']
+        power_unit['db_offset'] = [i for i in range(start_from, start_from+len(power_unit))]
         power_unit['version'] = get_data_version()
         power_unit['timestamp'] = str(datetime.now())
+        return power_unit
     except Exception as e:
         log.info(e)
-    return [start_from, power_unit]
 
 
 def download_power_unit(

--- a/soap_api/mastr_power_unit_download.py
+++ b/soap_api/mastr_power_unit_download.py
@@ -20,10 +20,6 @@ __version__ = "v0.9.0"
 import time
 from datetime import datetime as dt
 import logging
-import multiprocessing as mp
-from multiprocessing import get_context
-from multiprocessing.pool import ThreadPool 
-from functools import partial
 import pandas as pd
 import numpy as np
 from datetime import datetime
@@ -31,6 +27,8 @@ from zeep.helpers import serialize_object
 
 from soap_api.sessions import mastr_session, API_MAX_DEMANDS
 from soap_api.utils import split_to_sublists, write_to_csv, remove_csv, get_data_version, read_timestamp, TOTAL_POWER_UNITS
+from soap_api.parallel import parallel_download
+from soap_api.utils import fname_power_unit
 # from soap_api.mastr_wind_processing import do_wind
 
 log = logging.getLogger(__name__)
@@ -42,7 +40,6 @@ from soap_api.utils import fname_power_unit, fname_wind_unit, TIMESTAMP
 client, client_bind, token, user = mastr_session()
 api_key = token
 my_mastr = user
-
 
 def get_power_unit(start_from, wind=False, datum='1900-01-01 00:00:00.00000', limit=API_MAX_DEMANDS):
     """Get Stromerzeugungseinheit from API using GetGefilterteListeStromErzeuger.
@@ -82,7 +79,6 @@ def get_power_unit(start_from, wind=False, datum='1900-01-01 00:00:00.00000', li
         return power_unit
     except Exception as e:
         log.info(e)
-
 
 def download_power_unit(
         power_unit_list_len=TOTAL_POWER_UNITS,
@@ -140,11 +136,18 @@ def download_power_unit(
             log.exception(f'Download failed power_unit from {start_from}')
 
 
+# Helper function to pass more than one argument in parallel function call (multiprocess allows only a single argument to be passed, so we pass a tuple and destructure its contents here)
+def get_power_unit_helper(arg):
+    start_from, limit, wind = arg
+    return get_power_unit(start_from, limit=limit, wind=wind)
+
 def download_parallel_power_unit(
         power_unit_list_len=TOTAL_POWER_UNITS,
         limit=API_MAX_DEMANDS,
-        batch_size=10000,
         start_from=0,
+        threads=4,
+        timeout=10,
+        time_blacklist=True,
         overwrite=False, 
         wind=False,
         update=False
@@ -158,12 +161,15 @@ def download_parallel_power_unit(
         Maximum number of units to get. Check MaStR portal for current number.
     limit : int
         Number of units to get per call to API (limited to 2000).
-    batch_size : int
-        Number of elements in a batch.
-        Units from the list will be split into n batches of batch_size.
-        A higher batch size number means less threads but more retries.
     start_from : int
         Start index in the power_unit_list.
+    threads : int
+        number of parallel threads to download with
+    timeout : int
+        retry for this amount of minutes after the last successful
+        query before stopping
+    time_blacklist : bool
+        exit as soon as current time is blacklisted
     overwrite : bool
         Whether or not the data file should be overwritten.
     wind : bool
@@ -172,137 +178,33 @@ def download_parallel_power_unit(
         current max entries:
         42748 (2019-10-27)
         42481 (2019-11-28)
-    eeg : bool
-        Wether eeg data should be downloaded,too
     update: bool
         Wether a dataset should only be updated
     """
-    if wind==True:
+    # TODO: Not sure what this does
+    if wind is True:
         power_unit_list_len=42748
     update = TIMESTAMP
-    if update==True:
+    if update is True:
         datum = get_update_date(wind)
 
     log.info('Download MaStR Power Unit')
-    # if the batch_size is smaller than the api max allowed demands
-    if batch_size < API_MAX_DEMANDS:
-        limit = batch_size
-
-    if power_unit_list_len + start_from > TOTAL_POWER_UNITS:
-        deficit = (power_unit_list_len + start_from) - TOTAL_POWER_UNITS
-        power_unit_list_len = power_unit_list_len - deficit
-        if power_unit_list_len <= 0:
-            log.info('No entries to download. Decrease index size.')
-            return 0
-    end_at = power_unit_list_len + start_from
 
     if overwrite is True:
         remove_csv(fname_power_unit)
 
-    if power_unit_list_len < limit:
-        # less than one batch is to be downloaded
-        limit = power_unit_list_len
+    # Create a list of tuples with (start_from, limit, wind) to pass to thread. If list is not evenly divisible, the limit value of the last element is adjusted to be below the database limit
+    def unit_list(start, num, size):
+        items = num-start
+        l = [(i, size, wind) for i in range(start,num,size)]
+        if items % size != 0:
+            idx, size = l.pop()
+            l.append((idx, items%size, wind))
+        return l
 
-    log.info(f'Number of expected power units: {power_unit_list_len}')
+    units = unit_list(start_from, power_unit_list_len, limit)
 
-    log.info(f'Starting at index: {start_from}')
-    t = time.time()
-
-    # create a list of all indexes ranges to download (in batches of size given by limit)
-    start_from_list = list(range(start_from, end_at, limit + 1))
-    length = len(start_from_list)
-    num_batches = int(np.ceil(power_unit_list_len/batch_size))
-    assert num_batches >= 1
-    sublists = split_to_sublists(start_from_list, num_batches)
-    log.info('Number of batches to process: %s', num_batches)
-    summe = 0
-    length = len(sublists)
-    almost_end_of_list = False
-    end_of_list = False
-    failed_downloads = []
-    counter = 0
-    
-    # while there are still batches, try to download batch in parallel
-    while len(sublists) > 0:
-        # if there is only one batch left
-        if len(sublists) == 1:
-            # check wether the 1st round is done and if any downloads are in the failed_downloads list
-            if counter < 1 and len(failed_downloads) > 0:
-                    # add the failed downloads indexes to the first sublist
-                    sublists = sublists[0] + failed_downloads
-                    # recalculate the number of batches and sublists
-                    num_batches = int(np.ceil((len(failed_downloads)*2000)/batch_size))
-                    sublists = split_to_sublists(sublists, num_batches)
-                    counter = counter + 1
-                    summe = 0
-                    length = len(sublists)
-                    failed_downloads = []
-                    log.info('Starting second round with failed downloads')
-
-            # Set the variable to indicate that this is the last element (it is special because the
-            # size of the batch might be different than other batches, i.e. it might be the rest of
-            # the integer division of power_unit_list_len/API_MAX_DEMANDS
-            if almost_end_of_list is False:
-                almost_end_of_list = True
-            else:
-                # compute the rest of the integer division by API_MAX_DEMANDS
-                limit = np.mod(end_at - start_from, API_MAX_DEMANDS)
-                if limit == 0:
-                    # number of download is an integer number of API_MAX_DEMANDS
-                    limit = API_MAX_DEMANDS
-                end_of_list = True
-
-        # Main loop
-        try:
-            sublist = sublists.pop(0)
-            if len(sublists) > 1:
-                almost_end_of_list = False
-                end_of_list = False
-            if len(sublists) == 1:
-                end_of_list = False
-
-            # create pool and map all indices in batch sublist to one instance of get_power_unit
-            # use partial to partially preset some variables from get_power_unit
-            # 'spawn' is the only option to work on Windows and unix
-            # https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
-            pool = mp.get_context("spawn").Pool(processes=3)
-            if almost_end_of_list is False:
-                # Normal process
-                result = pool.map(partial(get_power_unit, limit=limit, wind=wind), sublist)
-            else:
-                if end_of_list is False:
-                    # The last batch size might not be an integer number of API_MAX_DEMANDS
-                    result = pool.map(partial(get_power_unit, limit=limit, wind=wind), sublist[:-1])
-                    # Evaluate the last item separately
-                    sublists.append([sublist[-1]])
-                else:
-                    result = pool.map(partial(get_power_unit, limit=limit, wind=wind), sublist)
-
-            # check for failed downloads and add indices of failed downloads to failed list
-            if len(result) != 0:
-                for ind, mylist in result:
-                    if mylist.empty:
-                        failed_downloads.append(ind)
-                    mylist['timestamp'] = datetime.now()
-                    if wind is False:
-                        write_to_csv(fname_power_unit, pd.DataFrame(mylist))
-                    else:
-                        write_to_csv(fname_wind_unit, pd.DataFrame(mylist))
-                log.info('Failed downloads: %s', len(failed_downloads))
-                pool.close()
-                pool.terminate()
-                pool.join()
-            else:
-                failed_downloads = failed_downloads + sublist
-                log.info('Download failed, retrying later')
-
-            # print progression
-            summe += 1
-            progress = np.floor((summe/length)*100)
-            print('\r[{0}{1}] %'.format('#'*(int(np.floor(progress/10))), '-'*int(np.floor((100-progress)/10))))
-        except Exception as e:
-            log.error(e)
-    log.info('Power Unit Download executed in: {0:.2f}'.format(time.time()-t))
+    parallel_download(units, get_power_unit_helper, fname_power_unit, threads=threads, timeout=timeout, time_blacklist=time_blacklist)
 
 
 """ check for new entries since TIMESTAMP """

--- a/soap_api/mastr_solar_download.py
+++ b/soap_api/mastr_solar_download.py
@@ -130,7 +130,13 @@ def read_power_unit_solar(csv_name):
 
 
 def download_parallel_unit_solar(unit_list, threads=4, timeout=10, time_blacklist=True):
-    return parallel_download(unit_list, get_power_unit_solar, fname_solar_unit, threads=threads, timeout=timeout, time_blacklist=time_blacklist)
+    return parallel_download(
+        unit_list,
+        get_power_unit_solar,
+        fname_solar_unit,
+        threads=threads,
+        timeout=timeout,
+        time_blacklist=time_blacklist)
 
 def get_power_unit_solar(mastr_unit_solar):
     """Get Solareinheit from API using GetEinheitSolar.
@@ -163,7 +169,6 @@ def get_power_unit_solar(mastr_unit_solar):
         return unit_solar
     except Exception as e:
         log.info('Download failed for {}: {}'.format(mastr_unit_solar, e))
-        return None
 
 
 def read_unit_solar(csv_name):
@@ -263,8 +268,15 @@ def read_unit_solar(csv_name):
     # log.info(f'Finished reading data from {csv_name}')
     return unit_solar
 
+
 def download_parallel_unit_solar_eeg(unit_list, threads=4, timeout=10, time_blacklist=True):
-    return parallel_download(unit_list, get_unit_solar_eeg, fname_solar_eeg, threads=threads, timeout=timeout, time_blacklist=time_blacklist)
+    return parallel_download(
+        unit_list,
+        get_unit_solar_eeg,
+        fname_solar_eeg,
+        threads=threads,
+        timeout=timeout,
+        time_blacklist=time_blacklist)
 
 def get_unit_solar_eeg(mastr_solar_eeg):
     """Get EEG-Anlage-Solar from API using GetAnlageEegSolar.

--- a/soap_api/mastr_solar_download.py
+++ b/soap_api/mastr_solar_download.py
@@ -131,7 +131,7 @@ def read_power_unit_solar(csv_name):
 
 
 # Download unit-solar (parallel)
-def download_parallel_unit_solar(unit_list, func, parallelism=4):
+def download_parallel_unit_solar(unit_list, func, filename, parallelism=4):
     """Download a list of units using a pool of threads
 
     Maps a download function for a single unit onto a list of
@@ -144,6 +144,8 @@ def download_parallel_unit_solar(unit_list, func, parallelism=4):
     func :
         Function to download an individual unit from the list,
         i.e. get_power_unit_xxx()
+    filename :
+        CSV file to write retrieved units to
     parallelism :
         number of threads to download with
     """
@@ -156,6 +158,7 @@ def download_parallel_unit_solar(unit_list, func, parallelism=4):
                 last_successful = datetime.datetime.now()
                 # TODO Check if low-level access can be done for all subfunctions
                 log.info('Unit {} sucessfully retrieved.'.format(unit.loc[1, 'EinheitMastrNummer']))
+                write_to_csv(filename, unit)
             # Last successful execution was more than 10 minutes ago, so stop execution
             # TODO make timeout value a function parameter
             if last_successful + datetime.timedelta(minutes=10) < datetime.datetime.now():
@@ -216,7 +219,6 @@ def get_power_unit_solar(mastr_unit_solar):
         unit_solar.index.names = ['lid']
         unit_solar['version'] = data_version
         unit_solar['timestamp'] = str(datetime.datetime.now())
-        write_to_csv(fname_solar_unit, unit_solar)
         return unit_solar
     except Exception as e:
         log.info('Download failed for {}: {}'.format(mastr_unit_solar, e))

--- a/soap_api/parallel.py
+++ b/soap_api/parallel.py
@@ -1,0 +1,50 @@
+import datetime
+import multiprocessing
+import logging
+
+from soap_api.utils import write_to_csv
+from soap_api.utils import is_time_blacklisted
+log = logging.getLogger(__name__)
+
+def parallel_download(unit_list, func, filename, threads=4, timeout=10, time_blacklist=True):
+    """Download a list of units using a pool of threads
+
+    Maps a download function for a single unit onto a list of
+    candidate units that are downloaded in parallel.
+
+    Arguments
+    ---------
+    unit_list : Iterable of 'EinheitMastrNummer' 
+        of units to download
+    func : callable function
+        Function to download an individual unit from the list,
+        i.e. get_power_unit_xxx()
+    filename : str
+        CSV file to write retrieved units to
+    threads : int
+        number of threads to download with
+    timeout : int
+        retry for this amount of minutes after the last successful
+        query before stopping
+    time_blacklist : bool
+        exit as soon as current time is blacklisted
+    """
+
+    with multiprocessing.Pool(threads) as pool:
+        last_successful = datetime.datetime.now()
+        for unit in pool.imap_unordered(func, unit_list):
+            now = datetime.datetime.now()
+            # Check if data was retrieved successfully
+            if unit is not None:
+                last_successful = now
+                # TODO Check if low-level access can be done for all subfunctions
+                log.info('Unit {} sucessfully retrieved.'.format(unit.loc[1, 'EinheitMastrNummer']))
+                write_to_csv(filename, unit)
+            # Last successful execution was more than 10 minutes ago, so stop execution
+            if last_successful + datetime.timedelta(minutes=timeout) < datetime.datetime.now():
+                log.error('No response from server in the last {} minutes. Stopping execution.'.format(timeout))
+                raise ConnectionAbortedError
+            # Stop execution if current system time is in blacklist
+            if time_blacklist and is_time_blacklisted(now.time()):
+                log.info('Current time is in blacklist. Halting.')
+                break

--- a/soap_api/parallel.py
+++ b/soap_api/parallel.py
@@ -6,6 +6,24 @@ from soap_api.utils import write_to_csv
 from soap_api.utils import is_time_blacklisted
 log = logging.getLogger(__name__)
 
+last_successful_download = datetime.datetime.now()
+
+# Check if worker threads need to be killed
+def _stop_execution(time_blacklist, timeout):
+    # Last successful execution was more than 10 minutes ago. Server seems unresponsive, so stop execution permanently by raising an error
+    if last_successful_download + datetime.timedelta(minutes=timeout) < datetime.datetime.now():
+        log.error('No response from server in the last {} minutes. Stopping execution.'.format(timeout))
+        raise ConnectionAbortedError
+    # Stop execution smoothly if current system time is in blacklist by returning. Calling function can decide to continue running later if needed
+    if time_blacklist and is_time_blacklisted(now.time()):
+        log.info('Current time is in blacklist. Halting.')
+        return True
+    # ... Add more checks here if needed ...
+    return False
+
+def _reset_timeout():
+    last_successful_download = datetime.datetime.now()
+
 def parallel_download(unit_list, func, filename, threads=4, timeout=10, time_blacklist=True):
     """Download a list of units using a pool of threads
 
@@ -30,21 +48,15 @@ def parallel_download(unit_list, func, filename, threads=4, timeout=10, time_bla
         exit as soon as current time is blacklisted
     """
 
+    _reset_timeout()
     with multiprocessing.Pool(threads) as pool:
-        last_successful = datetime.datetime.now()
         for unit in pool.imap_unordered(func, unit_list):
-            now = datetime.datetime.now()
             # Check if data was retrieved successfully
             if unit is not None:
-                last_successful = now
-                # TODO Check if low-level access can be done for all subfunctions
+                _reset_timeout()
+                # TODO Check if low-level access can be done for all potential subfunctions
+                # Alternatively turn this into a status bar
                 log.info('Unit {} sucessfully retrieved.'.format(unit.loc[1, 'EinheitMastrNummer']))
                 write_to_csv(filename, unit)
-            # Last successful execution was more than 10 minutes ago, so stop execution
-            if last_successful + datetime.timedelta(minutes=timeout) < datetime.datetime.now():
-                log.error('No response from server in the last {} minutes. Stopping execution.'.format(timeout))
-                raise ConnectionAbortedError
-            # Stop execution if current system time is in blacklist
-            if time_blacklist and is_time_blacklisted(now.time()):
-                log.info('Current time is in blacklist. Halting.')
+            if _stop_execution(time_blacklist, timeout) is True:
                 break

--- a/soap_api/parallel.py
+++ b/soap_api/parallel.py
@@ -10,20 +10,27 @@ log = logging.getLogger(__name__)
 last_successful_download = datetime.datetime.now()
 
 # Check if worker threads need to be killed
+
+
 def _stop_execution(time_blacklist, timeout):
-    # Last successful execution was more than 10 minutes ago. Server seems unresponsive, so stop execution permanently by raising an error
+    # Last successful execution was more than 10 minutes ago. Server seems
+    # unresponsive, so stop execution permanently by raising an error
     if last_successful_download + datetime.timedelta(minutes=timeout) < datetime.datetime.now():
         log.error('No response from server in the last {} minutes. Stopping execution.'.format(timeout))
         raise ConnectionAbortedError
-    # Stop execution smoothly if current system time is in blacklist by returning. Calling function can decide to continue running later if needed
+    # Stop execution smoothly if current system time is in blacklist by
+    # returning. Calling function can decide to continue running later if
+    # needed
     if time_blacklist and is_time_blacklisted(last_successful_download.time()):
         log.info('Current time is in blacklist. Halting.')
         return True
     # ... Add more checks here if needed ...
     return False
 
+
 def _reset_timeout():
     last_successful_download = datetime.datetime.now()
+
 
 def parallel_download(unit_list, func, filename, threads=4, timeout=10, time_blacklist=True):
     """Download a list of units using a pool of threads
@@ -33,7 +40,7 @@ def parallel_download(unit_list, func, filename, threads=4, timeout=10, time_bla
 
     Arguments
     ---------
-    unit_list : Iterable of 'EinheitMastrNummer' 
+    unit_list : Iterable of 'EinheitMastrNummer'
         of units to download
     func : callable function
         Function to download an individual unit from the list,

--- a/soap_api/sessions.py
+++ b/soap_api/sessions.py
@@ -16,19 +16,19 @@ __author__ = "Ludee; christian-rli"
 __issue__ = "https://github.com/OpenEnergyPlatform/examples/issues/52"
 __version__ = "v0.9.0"
 
-import config as lc
 
 # import getpass
 import os
+import sys
 import sqlalchemy as sa
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy import Column, Integer, String, Float, DateTime, Boolean
-from collections import namedtuple
 import requests
 import urllib3
 
-#from soap_api.utils import fname_hydro_all, fname_wind_all, fname_hydro_all, fname_biomass_all
+import soap_api.config as lc
 
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy import Column, Integer, String, Float, DateTime, Boolean
+from collections import namedtuple
 
 from zeep import Client, Settings
 from zeep.cache import SqliteCache
@@ -552,7 +552,6 @@ def oep_config():
         token = lc.config_file_get(config_section, 'token')
         print(f'Load API token')
     except:
-        import sys
         token = input('Token:')
         # token = getpass.getpass(prompt = 'Token:',
         #                         stream = sys.stdin)
@@ -766,10 +765,9 @@ def mastr_config():
 
     # token
     try:
-        from config import config_file_get
-        token = config_file_get(config_section, 'token')
+        token = lc.config_file_get(config_section, 'token')
     except:
-        import sys
+        # import sys
         token = input('Token:')
         # token = getpass.getpass(prompt='apiKey: ',
         #                            stream=sys.stderr)

--- a/soap_api/utils.py
+++ b/soap_api/utils.py
@@ -9,6 +9,7 @@ __version__ = "v0.9.0"
 import os
 import pandas as pd
 import logging
+import datetime
 log = logging.getLogger(__name__)
 
 DATA_VERSION = 'rli_v2.4.1'
@@ -189,3 +190,27 @@ def read_timestamp(wind=False):
             ts = ts.timestamp.iloc[-1]
             return ts
     return False
+
+def is_time_blacklisted(time):
+    times_blacklist = [
+            ('8:00', '18:00'), # BNetzA Business hours
+            ('23:30', '00:10'), # Daily database cronjob
+            # Add more if needed...
+            ]
+
+    # check if time is in a given interval between upper and lower
+    def in_interval(lower, upper):
+        # Convert str to datatime object
+        parse_time = lambda t: datetime.datetime.strptime(t, "%H:%M").time()
+        lower = parse_time(lower)
+        upper = parse_time(upper)
+
+        # Handle interval that spans over midnight (i.e. 23:30-0:30)
+        if lower > upper:
+            return (time <= upper or time >= lower)
+        # Handle all other intevals
+        return (lower <= time and upper >= time)
+
+    # check if time is in interval for each interval in the blacklist
+    in_interval = [in_interval(lower, upper) for lower, upper in times_blacklist]
+    return any(in_interval)

--- a/soap_api/utils.py
+++ b/soap_api/utils.py
@@ -191,17 +191,19 @@ def read_timestamp(wind=False):
             return ts
     return False
 
+
 def is_time_blacklisted(time):
     times_blacklist = [
-            ('8:00', '18:00'), # BNetzA Business hours
-            ('23:30', '00:10'), # Daily database cronjob
-            # Add more if needed...
-            ]
+        ('8:00', '18:00'),  # BNetzA Business hours
+        ('23:30', '00:10'),  # Daily database cronjob
+        # Add more if needed...
+    ]
 
     # check if time is in a given interval between upper and lower
     def in_interval(lower, upper):
         # Convert str to datatime object
-        parse_time = lambda t: datetime.datetime.strptime(t, "%H:%M").time()
+        def parse_time(t): 
+            return datetime.datetime.strptime(t, "%H:%M").time()
         lower = parse_time(lower)
         upper = parse_time(upper)
 


### PR DESCRIPTION
This separates the parallel download of elements into a single module.
The call interface of the parallel download functions is changed so that a list of `EinheitMastrNummer` of the items to be downloaded needs to be passed directly.

Furthermore this implements additional checks for:
- the time of day against a pre-defined blacklist to suppress execution during certain times of the day
- tracking of the time of the last successful retrieval of an item and error if database is not responsive

closes #96 
closes #95 
closes #94 
closes #93