### PR TITLE
Add option to backfill basic unit data for all technologies at once

### DIFF
--- a/open_mastr/soap_api/download.py
+++ b/open_mastr/soap_api/download.py
@@ -490,6 +490,14 @@ class MaStRDownload(metaclass=_MaStRDownloadFactory):
                 "unit_data": "GetEinheitGasVerbraucher",
                 "energietraeger": ["Erdgas"],
             },
+            "consumer": {
+                "unit_data": "GetEinheitStromVerbraucher",
+                "energietraeger": ["Strom"],
+            },
+            "gas_producer": {
+                "unit_data": "GetEinheitGasErzeuger",
+                "energietraeger": [None],
+            },
         }
 
         # Check if MaStR credentials are available and otherwise ask

--- a/open_mastr/soap_api/download.py
+++ b/open_mastr/soap_api/download.py
@@ -704,7 +704,7 @@ class MaStRDownload(metaclass=_MaStRDownloadFactory):
                         break
                 else:
                     log.error(f"Finally failed to download data."
-                              f"Basic unit data of index {chunk_start} to {chunk_start + limit_iter} will be missing.")
+                              f"Basic unit data of index {chunk_start} to {chunk_start + limit_iter - 1} will be missing.")
                     # TODO: this has potential risk! Please change
                     # If the download continuously fails on the last chunk, this query will run forever
                     response = {"Ergebniscode": 'OkWeitereDatenVorhanden'}

--- a/open_mastr/soap_api/download.py
+++ b/open_mastr/soap_api/download.py
@@ -484,7 +484,12 @@ class MaStRDownload(metaclass=_MaStRDownloadFactory):
             "gas_storage": {
                 "unit_data": "GetEinheitGasSpeicher",
                 "energietraeger": ["Speicher"],
-            }
+            },
+            # TODO: unsure if energietraeger Ergdas makes sense
+            "gas_consumer": {
+                "unit_data": "GetEinheitGasVerbraucher",
+                "energietraeger": ["Erdgas"],
+            },
         }
 
         # Check if MaStR credentials are available and otherwise ask

--- a/open_mastr/soap_api/download.py
+++ b/open_mastr/soap_api/download.py
@@ -480,6 +480,10 @@ class MaStRDownload(metaclass=_MaStRDownloadFactory):
                 "unit_data": "GetEinheitStromSpeicher",
                 "energietraeger": ["Speicher"],
                 "eeg_data": "GetAnlageEegSpeicher",
+            },
+            "gas_storage": {
+                "unit_data": "GetEinheitGasSpeicher",
+                "energietraeger": ["Speicher"],
             }
         }
 

--- a/open_mastr/soap_api/prototype_mastr_reflected.py
+++ b/open_mastr/soap_api/prototype_mastr_reflected.py
@@ -82,7 +82,8 @@ class MaStRReflected:
             "Geothermie": "gsgk",
             "Verbrennung": "combustion",
             "Kernenergie": "nuclear",
-            "Stromspeichereinheit": "storage"
+            "Stromspeichereinheit": "storage",
+            "Gasspeichereinheit": "gas_storage",
         }
 
     def initdb(self):

--- a/open_mastr/soap_api/prototype_mastr_reflected.py
+++ b/open_mastr/soap_api/prototype_mastr_reflected.py
@@ -293,20 +293,3 @@ class MaStRReflected:
                                 stderr=subprocess.PIPE,
                                 )
         proc.wait()
-
-limit = 1
-technology = "wind"
-
-mastr_refl = MaStRReflected(empty_schema=True)
-# mastr_refl.backfill_basic("solar", datetime.datetime(2020, 11, 27, 22, 0, 0), limit=10)
-mastr_refl.backfill_basic(technology, limit=limit)
-
-# Dump + restore data
-# dump_file = "open-mastr-continuous-update_wind-120000.backup"
-# mastr_refl.restore(dump_file)
-
-# Download additional unit data
-mastr_refl.retrieve_additional_data(technology, "unit_data", limit=limit)
-
-# Dump
-# mastr_refl.dump(dump_file)

--- a/open_mastr/soap_api/prototype_mastr_reflected.py
+++ b/open_mastr/soap_api/prototype_mastr_reflected.py
@@ -1,12 +1,9 @@
 import datetime
-import json
 import os
-from requests.exceptions import ConnectionError
 from sqlalchemy.orm import sessionmaker, Query
 from sqlalchemy import and_, create_engine
 import shlex
 import subprocess
-import time
 
 from open_mastr.soap_api.config import setup_logger
 from open_mastr.soap_api.download import MaStRDownload, _flatten_dict
@@ -20,12 +17,6 @@ engine = create_engine(
 )
 Session = sessionmaker(bind=engine)
 session = Session()
-
-# Create datadb.Base table
-# with engine.connect().execution_options(autocommit=True) as con:
-#     con.execute(f"CREATE SCHEMA IF NOT EXISTS {db.Base.metadata.schema}")
-# db.Base.metadata.create_all(engine)
-# db.BasicUnit.metadata.create_all(engine)
 
 
 def chunks(lst, n):

--- a/open_mastr/soap_api/prototype_mastr_reflected.py
+++ b/open_mastr/soap_api/prototype_mastr_reflected.py
@@ -85,6 +85,8 @@ class MaStRReflected:
             "Stromspeichereinheit": "storage",
             "Gasspeichereinheit": "gas_storage",
             "Gasverbrauchseinheit": "gas_consumer",
+            "Stromverbrauchseinheit": "consumer",
+            "Gaserzeugungseinheit": "gas_producer",
         }
 
     def initdb(self):

--- a/open_mastr/soap_api/prototype_mastr_reflected.py
+++ b/open_mastr/soap_api/prototype_mastr_reflected.py
@@ -106,6 +106,9 @@ class MaStRReflected:
             * `None`: Complete backfill
 
             Defaults to `None`.
+        limit: int
+            Maximum number of units.
+            Defaults to `None`.
         """
         # TODO: add keyword argument overwrite. If true, queried data overwrites existing without checking
         # TODO: Default is False, which refers to only inserting new or updated data (with newer timestamp than existing)

--- a/open_mastr/soap_api/prototype_mastr_reflected.py
+++ b/open_mastr/soap_api/prototype_mastr_reflected.py
@@ -84,6 +84,7 @@ class MaStRReflected:
             "Kernenergie": "nuclear",
             "Stromspeichereinheit": "storage",
             "Gasspeichereinheit": "gas_storage",
+            "Gasverbrauchseinheit": "gas_consumer",
         }
 
     def initdb(self):

--- a/tests/soap_api/test_download.py
+++ b/tests/soap_api/test_download.py
@@ -51,8 +51,11 @@ def test_soap_wrapper_power_plant_list(mastr_api):
 
 
 def test_basic_unit_data(mastr_download):
-    data = list(mastr_download.basic_unit_data("nuclear", 1))
+    data = [unit for sublist in mastr_download.basic_unit_data(
+        technology="nuclear",
+        limit=1
+    ) for unit in sublist]
 
     assert len(data) == 1
-    assert data[0]["Energietraeger"] == "Kernenergie"
+    assert data[0]["Einheittyp"] == "Kernenergie"
 

--- a/tests/soap_api/test_download.py
+++ b/tests/soap_api/test_download.py
@@ -1,4 +1,4 @@
-from open_mastr.soap_api.download import MaStRAPI
+from open_mastr.soap_api.download import MaStRAPI, MaStRDownload
 import pytest
 
 
@@ -10,6 +10,11 @@ def mastr_api_fake_credentials():
 @pytest.fixture
 def mastr_api():
     return MaStRAPI()
+
+
+@pytest.fixture
+def mastr_download():
+    return MaStRDownload()
 
 
 @pytest.mark.dependency(name="db_reachable")
@@ -30,8 +35,6 @@ def test_soap_wrapper_contingent(mastr_api):
 @pytest.mark.dependency(depends=["db_reachable"])
 def test_soap_wrapper_power_plant_list(mastr_api):
     response = mastr_api.GetGefilterteListeStromErzeuger(limit=1)
-    import pprint
-    pprint.pprint(response)
 
     for key in [
         "EinheitMastrNummer", "DatumLetzeAktualisierung", "Name",
@@ -45,3 +48,11 @@ def test_soap_wrapper_power_plant_list(mastr_api):
             assert key in einheit
 
     assert response['Ergebniscode'] == 'OkWeitereDatenVorhanden'
+
+
+def test_basic_unit_data(mastr_download):
+    data = list(mastr_download.basic_unit_data("nuclear", 1))
+
+    assert len(data) == 1
+    assert data[0]["Energietraeger"] == "Kernenergie"
+


### PR DESCRIPTION
This option was introduced in order to circumvent the not reachable web service function `GetGefilterteListeStromErzeuger`. Beyond that, it's quite handy to backfill all basic unit data at once. 