### PR TITLE
Remove unexpected line breaks during CSV export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ Read more about the details:
   [#112](https://github.com/OpenEnergyPlatform/open-MaStR/issues/112)
 - move code into one package named `open_mastr` [#123](https://github.com/OpenEnergyPlatform/open-MaStR/issues/123)
 - Switch to GitHub Actions for CI instead of Travis [#143](https://github.com/OpenEnergyPlatform/open-MaStR/issues/143)
+- Fixed unexpected line breaks during CSV export that corrupted data 
+  [#170](https://github.com/OpenEnergyPlatform/open-MaStR/issues/170)
 
 
 ### Removed

--- a/open_mastr/soap_api/mirror.py
+++ b/open_mastr/soap_api/mirror.py
@@ -763,6 +763,10 @@ class MaStRMirror:
             # Read data into pandas.DataFrame
             df = pd.read_sql(query.statement, query.session.bind, index_col="EinheitMastrNummer")
 
+            # Remove newline statements from certain strings
+            for col in ["Aktenzeichen", "Behoerde"]:
+                df[col] = df[col].str.replace("\r", "")
+
             # Make sure no duplicate column names exist
             assert not any(df.columns.duplicated())
 


### PR DESCRIPTION
Replacing `"\r"` in strings of some columns avoids unexpected line breaks.

Fixes #170.