### PR TITLE
Add warning message if the bulk download speed falls below a certain …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Here is a template for new release sections:
 ## [upcoming] Patch - Name of Release - 20YY-MM-DD
 
 ### Added
-- [#](https://github.com/rl-institut/super-repo/pull/)
+- Add warning message if the bulk download speed falls below a certain limit [#256](https://github.com/OpenEnergyPlatform/open-MaStR/issues/256)
 ### Changed
 - Fix combustion mapping [#253](https://github.com/rl-institut/super-repo/pull/253)
 - Update bulk parsing order [#257](https://github.com/rl-institut/super-repo/pull/257)
@@ -40,7 +40,6 @@ Here is a template for new release sections:
 
 ### Added
 - Add files and metadata for PyPi release [#237](https://github.com/OpenEnergyPlatform/open-MaStR/issues/237)
-
 
 ##  [v0.11.0] Unreleased - Forces unite - 2022-05-16
 

--- a/open_mastr/xml_download/utils_download_bulk.py
+++ b/open_mastr/xml_download/utils_download_bulk.py
@@ -35,13 +35,17 @@ def download_xml_Mastr(save_path: str) -> None:
         "Download has started, this can take several minutes."
         "The download bar is only a rough estimate."
     )
+    warning_message = (
+        "Warning: The servers from MaStR restricts the download speed."
+        " You may want to download it another time."
+    )
     print(print_message)
     url = get_url_from_Mastr_website()
     time_a = time.perf_counter()
     r = requests.get(url, stream=True)
     total_length = int(10000 * 1024 * 1024)
     with open(save_path, "wb") as zfile, tqdm(
-        desc=save_path, total=(total_length / 1024 / 1024)
+        desc=save_path, total=(total_length / 1024 / 1024), unit="MB"
     ) as bar:
         for chunk in r.iter_content(chunk_size=1024 * 1024):
             # chunk size of 1024 * 1024 needs 9min 11 sek = 551sek
@@ -50,5 +54,11 @@ def download_xml_Mastr(save_path: str) -> None:
                 zfile.write(chunk)
                 zfile.flush()
             bar.update()
+            # if the rate falls below 100 kB/s -> prompt warning
+            if bar.format_dict["rate"] and bar.format_dict["rate"] < 0.1:
+                bar.set_postfix_str(s=warning_message)
+            else:
+                # remove warning
+                bar.set_postfix_str(s="")
     time_b = time.perf_counter()
     print(f"Download is finished. It took {int(np.around(time_b - time_a))} seconds.")

--- a/open_mastr/xml_download/utils_download_bulk.py
+++ b/open_mastr/xml_download/utils_download_bulk.py
@@ -36,7 +36,7 @@ def download_xml_Mastr(save_path: str) -> None:
         "The download bar is only a rough estimate."
     )
     warning_message = (
-        "Warning: The servers from MaStR restricts the download speed."
+        "Warning: The servers from MaStR restrict the download speed."
         " You may want to download it another time."
     )
     print(print_message)


### PR DESCRIPTION
…limit #256

* The limit is set to 100kB/s
* The unit of tqdm bar is set to MB, since each iteration corresponds to one megabyte

closes #256