### PR TITLE
Separate ci workflows for develop and production branch #287

### DIFF
--- a/.github/workflows/ci-develop.yml
+++ b/.github/workflows/ci-develop.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  build:
+
+    # Jobs definition
+    runs-on: ${{ matrix.os }}
+    if: ${{ !github.event.pull_request.draft }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        python-version: [3.9, '3.10']
+    name: pytest (Python ${{ matrix.python-version }}) (OS ${{ matrix.os }})
+
+    # Configure tests
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e ".[dev]"
+    - name: Create credentials file
+      env:
+        MASTR_TOKEN: ${{ secrets.MASTR_TOKEN }}
+        MASTR_USER: ${{ secrets.MASTR_USER }}
+      run: |
+        python -c "from tests import preparation; preparation.create_credentials_file()"
+    - name: Test with pytest
+      run: |
+        pytest -vv

--- a/.github/workflows/ci-production.yml
+++ b/.github/workflows/ci-production.yml
@@ -3,11 +3,9 @@ name: CI
 on:
   push:
     branches:
-      - develop
       - production
   pull_request:
     branches:
-      - develop
       - production
 
 jobs:
@@ -18,8 +16,8 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        python-version: [3.8, 3.9, '3.10']
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        python-version: [3.9, '3.10']
     name: pytest (Python ${{ matrix.python-version }}) (OS ${{ matrix.os }})
 
     # Configure tests
@@ -32,13 +30,19 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e ".[dev]"
+    - name: create package
+      run: python setup.py sdist
+    - name: import open-mastr
+      run: python -m pip install ./dist/open_mastr-0.11.4.tar.gz	
     - name: Create credentials file
       env:
         MASTR_TOKEN: ${{ secrets.MASTR_TOKEN }}
         MASTR_USER: ${{ secrets.MASTR_USER }}
       run: |
         python -c "from tests import preparation; preparation.create_credentials_file()"
+    - name: Install pytest
+      run: |
+        python -m pip install pytest
     - name: Test with pytest
       run: |
         pytest -vv


### PR DESCRIPTION
* In case of a pull request on production branch the package is built by sdist and then the zipped artefact is pip installed instead of the directory with setup.py
This helps to verify that the built package is indeed self-sufficient.
* The test cases are reduced to two python versions but the macos is included as third os.