### PR TITLE
Bugfix 300 linked permit units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Here is a template for new release sections:
 - [#](https://github.com/rl-institut/super-repo/pull/)
 ### Changed
 - Use exclusively sqlalchemy for dialect-free implementation [#289](https://github.com/OpenEnergyPlatform/open-MaStR/pull/289)
+- API Download: Linked units in table permit are written in comma seperated string [#302](https://github.com/OpenEnergyPlatform/open-MaStR/pull/302)
 ### Removed
 - [#](https://github.com/rl-institut/super-repo/pull/)
 

--- a/open_mastr/soap_api/download.py
+++ b/open_mastr/soap_api/download.py
@@ -243,7 +243,6 @@ def flatten_dict(data, serialize_with_json=False):
     Flattens MaStR data dictionary to depth of one
 
     Parameters
-    Parameters
     ----------
     data : list of dict
         Data returned from MaStR-API query
@@ -293,17 +292,18 @@ def flatten_dict(data, serialize_with_json=False):
         for k, v in flatten_rule_replace.items():
             if k in dic.keys():
                 dic[k] = dic[k][v]
-
         # Replacement with second-level value from second-level list
         for k, v in flatten_rule_replace_list.items():
             if k in dic.keys() and len(dic[k]) != 0:
+                mastr_nr_list = [unit[v] for unit in dic[k]]
+                entry_temp = ", ".join(mastr_nr_list)
 
                 # if data point in 'dic' has one or more VerknuepfteEinheit or
                 # VerknuepfteEinheiten in its respective
                 # dict, then take first MaStRNummer and insert it into key
                 # VerknuepfteEinheiten (flatten dict).
                 # Discard all other connected MaStRNummer's of data point.
-                dic[k] = dic[k][0][v]
+                dic[k] = entry_temp
 
         # Serilializes dictionary entries with unknown number of sub-entries into JSON string
         # This affects "Ertuechtigung" in extended unit data of hydro
@@ -588,10 +588,14 @@ class MaStRDownload(metaclass=_MaStRDownloadFactory):
         ]
 
         # Prepare list of unit ID for different additional data (extended, eeg, kwk, permit)
-        mastr_ids = self._create_ID_list(units, "unit_data", "EinheitMastrNummer", technology)
+        mastr_ids = self._create_ID_list(
+            units, "unit_data", "EinheitMastrNummer", technology
+        )
         eeg_ids = self._create_ID_list(units, "eeg_data", "EegMastrNummer", technology)
         kwk_ids = self._create_ID_list(units, "kwk_data", "KwkMastrNummer", technology)
-        permit_ids = self._create_ID_list(units, "permit_data", "GenMastrNummer", technology)
+        permit_ids = self._create_ID_list(
+            units, "permit_data", "GenMastrNummer", technology
+        )
 
         # Download additional data for unit
         extended_data, extended_missed = self.additional_data(
@@ -678,8 +682,11 @@ class MaStRDownload(metaclass=_MaStRDownloadFactory):
 
     def _create_ID_list(self, units, data_descriptor, key, technology):
         """Extracts a list of MaStR numbers (eeg, kwk, or permit Mastr Nr) from the given units."""
-        return [basic[key] for basic in units if basic[key]] if data_descriptor in self._unit_data_specs[technology] else []
-
+        return (
+            [basic[key] for basic in units if basic[key]]
+            if data_descriptor in self._unit_data_specs[technology]
+            else []
+        )
 
     def basic_unit_data(
         self, technology=None, limit=2000, date_from=None, max_retries=3

--- a/open_mastr/soap_api/download.py
+++ b/open_mastr/soap_api/download.py
@@ -284,8 +284,7 @@ def replace_second_level_keys_with_first_level_data(dic: dict) -> dict:
 
 def replace_linked_units_with_unit_identifier(dic: dict) -> dict:
     """If data point in 'dic' has one or more VerknuepfteEinheit or
-    VerknuepfteEinheiten in its respective dict, then take first MaStRNummer
-    and insert it into key VerknuepfteEinheiten (flatten dict).
+    VerknuepfteEinheiten in its respective dict, the related units (VerknuepfteEinheiten) are inserted as comma-separated strings.
 
     Parameters
     ----------

--- a/open_mastr/soap_api/download.py
+++ b/open_mastr/soap_api/download.py
@@ -238,22 +238,22 @@ def _mastr_suppress_parsing_errors(which_errors):
     ] + [f for f in error_filters if f.name in which_errors]
 
 
-def flatten_dict(data, serialize_with_json=False):
-    """
-    Flattens MaStR data dictionary to depth of one
+def replace_second_level_keys_with_first_level_data(dic: dict) -> dict:
+    """The returned dict from the API call often contains nested dicts. The
+    columns where this happens are defined in flatten_rule_replace. The nested dicts
+    are replaced by its actual value.
+
 
     Parameters
     ----------
-    data : list of dict
-        Data returned from MaStR-API query
+    dic : dict
+        Dictionary containing information on single unit
 
     Returns
     -------
-    list of dict
-        Flattened data dictionary
+    dict
+        Dictionary where nested entries are replaced by data of interest
     """
-
-    # The rule describes which of the second-level keys are used to replace first-level data
     flatten_rule_replace = {
         "Hausnummer": "Wert",
         "Kraftwerksnummer": "Wert",
@@ -271,39 +271,88 @@ def flatten_dict(data, serialize_with_json=False):
         "Frist": "Wert",
         "WasserrechtAblaufdatum": "Wert",
     }
+    for k, v in flatten_rule_replace.items():
+        if k in dic:
+            dic[k] = dic[k][v]
+
+    return dic
+
+
+def replace_linked_units_with_unit_identifier(dic: dict) -> dict:
+    """If data point in 'dic' has one or more VerknuepfteEinheit or
+    VerknuepfteEinheiten in its respective dict, then take first MaStRNummer
+    and insert it into key VerknuepfteEinheiten (flatten dict).
+
+    Parameters
+    ----------
+    dic : dict
+        Dictionary containing information on single unit
+
+    Returns
+    -------
+    dict
+        Dictionary where linked units are replaced with linked unit identifier (MaStRNummer)
+    """
 
     flatten_rule_replace_list = {
         "VerknuepfteEinheit": "MaStRNummer",
         "VerknuepfteEinheiten": "MaStRNummer",
     }
+    for k, v in flatten_rule_replace_list.items():
+        if k in dic and len(dic[k]) != 0:
+            mastr_nr_list = [unit[v] for unit in dic[k]]
+            dic[k] = ", ".join(mastr_nr_list)
+    return dic
 
-    flatten_rule_serialize = ["Ertuechtigung"]
 
-    flatten_rule_move_up_and_merge = ["Hersteller"]
+def replace_entries_of_type_list(dic: dict) -> dict:
+    """Entries that are lists are replaced:
+    Empty lists are replaced with None.
+    Lists of strings are replaced with comma seperated strings.
 
+    Parameters
+    ----------
+    dic : dict
+        Dictionary containing information on single unit
+
+    Returns
+    -------
+    dict
+        Dictionary containing information on single unit without list entries.
+    """
     flatten_rule_none_if_empty_list = [
         "ArtDerFlaeche",
         "WeitereBrennstoffe",
         "VerknuepfteErzeugungseinheiten",
     ]
+    for k in flatten_rule_none_if_empty_list:
+        if k in dic:
+            dic[k] = None if dic[k] == [] else ",".join(dic[k])
+    return dic
+
+
+def flatten_dict(data: list, serialize_with_json: bool = False) -> list:
+    """
+    Flattens MaStR data dictionary to depth of one
+
+    Parameters
+    ----------
+    data : list of dict
+        Data returned from MaStR-API query
+
+    Returns
+    -------
+    list of dict
+        Flattened data dictionary
+    """
+
+    flatten_rule_serialize = ["Ertuechtigung"]
+
+    flatten_rule_move_up_and_merge = ["Hersteller"]
 
     for dic in data:
-        # Replacements with second-level values
-        for k, v in flatten_rule_replace.items():
-            if k in dic.keys():
-                dic[k] = dic[k][v]
-        # Replacement with second-level value from second-level list
-        for k, v in flatten_rule_replace_list.items():
-            if k in dic.keys() and len(dic[k]) != 0:
-                mastr_nr_list = [unit[v] for unit in dic[k]]
-                entry_temp = ", ".join(mastr_nr_list)
-
-                # if data point in 'dic' has one or more VerknuepfteEinheit or
-                # VerknuepfteEinheiten in its respective
-                # dict, then take first MaStRNummer and insert it into key
-                # VerknuepfteEinheiten (flatten dict).
-                # Discard all other connected MaStRNummer's of data point.
-                dic[k] = entry_temp
+        dic = replace_second_level_keys_with_first_level_data(dic)
+        dic = replace_linked_units_with_unit_identifier(dic)
 
         # Serilializes dictionary entries with unknown number of sub-entries into JSON string
         # This affects "Ertuechtigung" in extended unit data of hydro
@@ -319,11 +368,7 @@ def flatten_dict(data, serialize_with_json=False):
                 dic.update({k + "Id": dic[k]["Id"]})
                 dic.update({k: dic[k]["Wert"]})
 
-        # Avoid empty lists as values
-        for k in flatten_rule_none_if_empty_list:
-            if k in dic.keys():
-                dic[k] = None if dic[k] == [] else ",".join(dic[k])
-
+        dic = replace_entries_of_type_list(dic)
     return data
 
 

--- a/open_mastr/soap_api/download.py
+++ b/open_mastr/soap_api/download.py
@@ -243,6 +243,10 @@ def replace_second_level_keys_with_first_level_data(dic: dict) -> dict:
     columns where this happens are defined in flatten_rule_replace. The nested dicts
     are replaced by its actual value.
 
+    Example:
+    "WasserrechtAblaufdatum": {"Wert": None, "NichtVorhanden": False}
+    -> "WasserrechtAblaufdatum": None
+
 
     Parameters
     ----------
@@ -345,7 +349,6 @@ def flatten_dict(data: list, serialize_with_json: bool = False) -> list:
     list of dict
         Flattened data dictionary
     """
-
     flatten_rule_serialize = ["Ertuechtigung"]
 
     flatten_rule_move_up_and_merge = ["Hersteller"]

--- a/tests/soap_api/test_download.py
+++ b/tests/soap_api/test_download.py
@@ -1,5 +1,6 @@
-from open_mastr.soap_api.download import MaStRAPI, MaStRDownload
+from open_mastr.soap_api.download import MaStRAPI, MaStRDownload, flatten_dict
 import pytest
+import datetime
 
 
 @pytest.fixture
@@ -101,3 +102,116 @@ def test_additional_data_biomass(mastr_download):
         )
 
         assert len(units_downloaded) + len(units_missed) == 1
+
+
+def test_flatten_dict():
+    data_before_flatten = [
+        {
+            "Frist": {"Wert": datetime.date(2017, 6, 15), "NichtVorhanden": False},
+            "WasserrechtsNummer": None,
+            "WasserrechtAblaufdatum": {"Wert": None, "NichtVorhanden": False},
+            "Registrierungsdatum": datetime.date(2019, 9, 11),
+            "VerknuepfteEinheiten": [
+                {
+                    "MaStRNummer": "SEE900290686291",
+                    "Einheittyp": "Windeinheit",
+                    "Einheitart": "Stromerzeugungseinheit",
+                }
+            ],
+        },
+        {
+            "Frist": {"Wert": datetime.date(2018, 3, 27), "NichtVorhanden": False},
+            "WasserrechtsNummer": None,
+            "WasserrechtAblaufdatum": {"Wert": None, "NichtVorhanden": False},
+            "Registrierungsdatum": datetime.date(2019, 2, 4),
+            "VerknuepfteEinheiten": [
+                {
+                    "MaStRNummer": "SEE908999761141",
+                    "Einheittyp": "Windeinheit",
+                    "Einheitart": "Stromerzeugungseinheit",
+                },
+                {
+                    "MaStRNummer": "SEE978389475514",
+                    "Einheittyp": "Windeinheit",
+                    "Einheitart": "Stromerzeugungseinheit",
+                },
+                {
+                    "MaStRNummer": "SEE960287756734",
+                    "Einheittyp": "Windeinheit",
+                    "Einheitart": "Stromerzeugungseinheit",
+                },
+            ],
+        },
+        {
+            "Frist": {"Wert": datetime.date(2018, 3, 23), "NichtVorhanden": False},
+            "WasserrechtsNummer": None,
+            "WasserrechtAblaufdatum": {"Wert": None, "NichtVorhanden": False},
+            "Registrierungsdatum": datetime.date(2019, 2, 15),
+            "VerknuepfteEinheiten": [
+                {
+                    "MaStRNummer": "SEE902566900605",
+                    "Einheittyp": "Windeinheit",
+                    "Einheitart": "Stromerzeugungseinheit",
+                },
+                {
+                    "MaStRNummer": "SEE945851284479",
+                    "Einheittyp": "Windeinheit",
+                    "Einheitart": "Stromerzeugungseinheit",
+                },
+                {
+                    "MaStRNummer": "SEE975973981666",
+                    "Einheittyp": "Windeinheit",
+                    "Einheitart": "Stromerzeugungseinheit",
+                },
+            ],
+        },
+        {
+            "Frist": {"Wert": datetime.date(2016, 1, 23), "NichtVorhanden": False},
+            "WasserrechtsNummer": None,
+            "WasserrechtAblaufdatum": {"Wert": None, "NichtVorhanden": False},
+            "Registrierungsdatum": datetime.date(2019, 2, 7),
+            "VerknuepfteEinheiten": [
+                {
+                    "MaStRNummer": "SEE969499157391",
+                    "Einheittyp": "Windeinheit",
+                    "Einheitart": "Stromerzeugungseinheit",
+                },
+                {
+                    "MaStRNummer": "SEE949984955732",
+                    "Einheittyp": "Windeinheit",
+                    "Einheitart": "Stromerzeugungseinheit",
+                },
+            ],
+        },
+    ]
+    data_after_flatten = [
+        {
+            "Frist": datetime.date(2017, 6, 15),
+            "WasserrechtsNummer": None,
+            "WasserrechtAblaufdatum": None,
+            "Registrierungsdatum": datetime.date(2019, 9, 11),
+            "VerknuepfteEinheiten": "SEE900290686291",
+        },
+        {
+            "Frist": datetime.date(2018, 3, 27),
+            "WasserrechtsNummer": None,
+            "WasserrechtAblaufdatum": None,
+            "Registrierungsdatum": datetime.date(2019, 2, 4),
+            "VerknuepfteEinheiten": "SEE908999761141, SEE978389475514, SEE960287756734",
+        },
+        {
+            "Frist": datetime.date(2018, 3, 23),
+            "WasserrechtsNummer": None,
+            "WasserrechtAblaufdatum": None,
+            "Registrierungsdatum": datetime.date(2019, 2, 15),
+            "VerknuepfteEinheiten": "SEE902566900605, SEE945851284479, SEE975973981666",
+        },
+        {
+            "Frist": datetime.date(2016, 1, 23),
+            "WasserrechtsNummer": None,
+            "WasserrechtAblaufdatum": None,
+            "Registrierungsdatum": datetime.date(2019, 2, 7),
+            "VerknuepfteEinheiten": "SEE969499157391, SEE949984955732",
+        },
+    ]
+    assert flatten_dict(data_before_flatten) == data_after_flatten


### PR DESCRIPTION
Units that are linked to one permit are now all written to the permit table in a comma seperated string.
Issue: #300 