### PR TITLE
Read version number for CI from setup.py

### DIFF
--- a/.github/workflows/ci-production.yml
+++ b/.github/workflows/ci-production.yml
@@ -33,7 +33,10 @@ jobs:
     - name: create package
       run: python setup.py sdist
     - name: import open-mastr
-      run: python -m pip install ./dist/open_mastr-0.11.6.tar.gz	
+      run: |
+        version_number=$(python setup.py --version)
+        wheel_name="./dist/open_mastr-"$version_number".tar.gz"
+        python -m pip install $wheel_name	
     - name: Create credentials file
       env:
         MASTR_TOKEN: ${{ secrets.MASTR_TOKEN }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     ],
     version="0.11.6",
     description="A package that provides an interface for downloading and"
-    "processing the data of the Marktstammdatenregister (MaStR)",
+    " processing the data of the Marktstammdatenregister (MaStR)",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/OpenEnergyPlatform/open-MaStR",


### PR DESCRIPTION
The version in ci-production.yml is not anymore hardcoded, but read from setup.py. The workflow is tested on my fork. 

Additional minor changes

#322