### PR TITLE
Unite two date parameter into one #346

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Here is a template for new release sections:
 ### Changed
 - Technology parameter is renamed to data for better comprehension [#337](https://github.com/OpenEnergyPlatform/open-MaStR/pull/337)
 - Update ORM and documentation according to wsdl patch V1.2.87 [#352](https://github.com/OpenEnergyPlatform/open-MaStR/pull/352)
+- Date parameters are united into one parameter [#353](https://github.com/OpenEnergyPlatform/open-MaStR/pull/353)
 
 ### Removed
 - Removed code artefacts [#335](https://github.com/OpenEnergyPlatform/open-MaStR/pull/335)

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -53,7 +53,7 @@ additional parameters can be set to define in detail which data should be obtain
      - Select data to download.
    * - date
      - None or :class:`datetime.datetime` or str
-     - Specify backfill date from which on data is retrieved. Only data with time stamp greater than `date` will be retrieved. Defaults to `None`.
+     - Specify backfill date from which on data is retrieved. Only data with time stamp greater than `date` will be retrieved. Defaults to `None` which means that todays date is chosen.
    * - api_data_types
      - ["unit_data","eeg_data","kwk_data","permit_data"]
      - Select the type of data to download.

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -51,6 +51,9 @@ additional parameters can be set to define in detail which data should be obtain
    * - data
      - ["wind","biomass","combustion","gsgk","hydro","nuclear","storage","solar"]
      - Select data to download.
+   * - date
+     - None or :class:`datetime.datetime` or str
+     - Specify backfill date from which on data is retrieved. Only data with time stamp greater than `date` will be retrieved. Defaults to `None`.
    * - api_data_types
      - ["unit_data","eeg_data","kwk_data","permit_data"]
      - Select the type of data to download.
@@ -63,9 +66,6 @@ additional parameters can be set to define in detail which data should be obtain
    * - api_limit
      - Number of type int, e.g.: 1500
      - Select the number of entries to download. Defaults to 50.
-   * - api_date
-     - None or :class:`datetime.datetime` or str
-     - Specify backfill date from which on data is retrieved. Only data with time stamp greater that `api_date` will be retrieved. Defaults to `None`.
    * - api_chunksize
      - int or None, e.g.: 1000
      - Data is downloaded and inserted into the database in chunks of `api_chunksize`. Defaults to 1000.

--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ from open_mastr import Mastr
 ## specify download parameter
 
 # bulk download
-bulk_date_string = "today"
+bulk_date = "today"
 bulk_cleansing = True
 data_bulk = [
     "biomass",
@@ -69,20 +69,15 @@ db = Mastr()
 if __name__ == "__main__":
     ## download Markstammdatenregister
     # bulk download
-    db.download(
-        method="bulk",
-        data=data_bulk,
-        bulk_date_string="today",
-        bulk_cleansing=True,
-    )
+    db.download(method="bulk", data=data_bulk, date=bulk_date, bulk_cleansing=True)
 
     # API download
     db.download(
         method="API",
         data=data_api,
+        date=api_date,
         api_processes=api_processes,
         api_limit=api_limit,
-        api_date=api_date,
         api_chunksize=api_chunksize,
         api_data_types=api_data_types,
         api_location_types=api_location_types,

--- a/open_mastr/utils/helpers.py
+++ b/open_mastr/utils/helpers.py
@@ -82,23 +82,32 @@ def validate_parameter_format_for_mastr_init(engine) -> None:
 def validate_parameter_format_for_download_method(
     method,
     data,
-    bulk_date_string,
+    date,
     bulk_cleansing,
     api_processes,
     api_limit,
-    api_date,
     api_chunksize,
     api_data_types,
     api_location_types,
+    **kwargs,
 ) -> None:
+
+    if "technology" in kwargs:
+        data = kwargs["technology"]
+        warn("'technology' parameter is deprecated. Use 'data' instead")
+    if "bulk_date" in kwargs:
+        date = kwargs["bulk_date"]
+        warn("'bulk_date' parameter is deprecated. Use 'date' instead")
+    if "api_date" in kwargs:
+        date = kwargs["api_date"]
+        warn("'api_date' parameter is deprecated. Use 'date' instead")
 
     validate_parameter_method(method)
     validate_parameter_data(method, data)
-    validate_parameter_bulk_date_string(bulk_date_string)
+    validate_parameter_date(method, date)
     validate_parameter_bulk_cleansing(bulk_cleansing)
     validate_parameter_api_processes(api_processes)
     validate_parameter_api_limit(api_limit)
-    validate_parameter_api_date(api_date)
     validate_parameter_api_chunksize(api_chunksize)
     validate_parameter_api_data_types(api_data_types)
     validate_parameter_api_location_types(api_location_types)
@@ -106,9 +115,8 @@ def validate_parameter_format_for_download_method(
     raise_warning_for_invalid_parameter_combinations(
         method,
         bulk_cleansing,
-        bulk_date_string,
+        date,
         api_processes,
-        api_date,
         api_data_types,
         api_location_types,
         api_limit,
@@ -159,27 +167,26 @@ def validate_parameter_bulk_cleansing(bulk_cleansing) -> None:
         raise ValueError("parameter bulk_cleansing has to be boolean")
 
 
-def validate_parameter_api_date(api_date) -> None:
-    if not isinstance(api_date, datetime) and api_date not in ["latest", None]:
-        raise ValueError(
-            "parameter api_date has to be 'latest' or a datetime object or 'None'."
-        )
-
-
 def validate_parameter_api_limit(api_limit) -> None:
     if not isinstance(api_limit, int) and api_limit is not None:
         raise ValueError("parameter api_limit has to be an integer or 'None'.")
 
 
-def validate_parameter_bulk_date_string(bulk_date_string) -> None:
-    if bulk_date_string != "today":
-        try:
-            _ = parse(bulk_date_string)
-        except (dateutil.parser._parser.ParserError, TypeError) as e:
+def validate_parameter_date(method, date) -> None:
+    if method == "bulk":
+        if date != "today":
+            try:
+                _ = parse(date)
+            except (dateutil.parser._parser.ParserError, TypeError) as e:
+                raise ValueError(
+                    "Parameter date has to be a proper date in the format yyyymmdd"
+                    "or 'today' for bulk method."
+                ) from e
+    elif method == "API":
+        if not isinstance(date, datetime) and date not in ["latest", None]:
             raise ValueError(
-                "parameter bulk_date_string has to be a proper date in the format yyyymmdd"
-                "or 'today'."
-            ) from e
+                "parameter api_date has to be 'latest' or a datetime object or 'None' for API method."
+            )
 
 
 def validate_parameter_api_processes(api_processes) -> None:
@@ -218,15 +225,14 @@ def validate_parameter_data(method, data) -> None:
 def raise_warning_for_invalid_parameter_combinations(
     method,
     bulk_cleansing,
-    bulk_date_string,
+    date,
     api_processes,
-    api_date,
     api_data_types,
     api_location_types,
     api_limit,
     api_chunksize,
 ):
-    if method == "API" and (bulk_cleansing is not True or bulk_date_string != "today"):
+    if method == "API" and (bulk_cleansing is not True or date != "today"):
         warn(
             "For method = 'API', bulk download related parameters "
             "(with prefix bulk_) are ignored."
@@ -238,7 +244,6 @@ def raise_warning_for_invalid_parameter_combinations(
                 parameter is not None
                 for parameter in [
                     api_processes,
-                    api_date,
                     api_data_types,
                     api_location_types,
                 ]
@@ -252,11 +257,14 @@ def raise_warning_for_invalid_parameter_combinations(
         )
 
 
-def transform_data_parameter(method, data, api_data_types, api_location_types):
+def transform_data_parameter(
+    method, data, api_data_types, api_location_types, **kwargs
+):
     """
     Parse input parameters related to data as lists. Harmonize variables for later use.
     Data output depends on the possible data types of chosen method.
     """
+    data = kwargs.get("technology", data)
     # parse parameters as list
     if isinstance(data, str):
         data = [data]
@@ -284,6 +292,16 @@ def transform_data_parameter(method, data, api_data_types, api_location_types):
     return data, api_data_types, api_location_types, harmonisation_log
 
 
+def transform_date_parameter(method, date, **kwargs):
+
+    if method == "bulk":
+        date = kwargs.get("bulk_date", date)
+    elif method == "API":
+        date = kwargs.get("api_date", date)
+
+    return date
+
+
 @contextmanager
 def session_scope(engine):
     """Provide a transactional scope around a series of operations."""
@@ -302,7 +320,7 @@ def session_scope(engine):
 def print_api_settings(
     harmonisation_log,
     data,
-    api_date,
+    date,
     api_data_types,
     api_chunksize,
     api_limit,
@@ -312,7 +330,7 @@ def print_api_settings(
 
     print(
         f"Downloading with soap_API.\n\n   -- API settings --  \nunits after date: "
-        f"{api_date}\nunit download limit per data: "
+        f"{date}\nunit download limit per data: "
         f"{api_limit}\nparallel_processes: {api_processes}\nchunksize: "
         f"{api_chunksize}\ndata_api: {data}"
     )

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,3 +1,4 @@
+from open_mastr.utils.constants import API_LOCATION_TYPES
 from open_mastr.utils.helpers import (
     validate_parameter_format_for_download_method,
     validate_parameter_format_for_mastr_init,
@@ -16,9 +17,9 @@ def db():
 
 
 @pytest.fixture
-def parameter_dict_working():
-    parameter_dict = {
-        "method": ["API", "bulk"],
+def parameter_dict_working_list():
+    parameter_dict_bulk = {
+        "method": ["bulk"],
         "data": [
             "wind",
             "solar",
@@ -38,13 +39,37 @@ def parameter_dict_working():
             None,
             ["wind", "solar"],
         ],
-        "bulk_date_string": ["today", "20200108"],
+        "date": ["today", "20200108"],
         "bulk_cleansing": [True, False],
+        "api_processes": [None],
+        "api_limit": [50],
+        "api_chunksize": [1000],
+        "api_data_types": [None],
+        "api_location_types": [None],
+    }
+
+    parameter_dict_API = {
+        "method": ["API"],
+        "data": [
+            "wind",
+            "solar",
+            "biomass",
+            "hydro",
+            "gsgk",
+            "combustion",
+            "nuclear",
+            "storage",
+            "location",
+            "permit",
+            None,
+            ["wind", "solar"],
+        ],
+        "date": [None, datetime(2022, 2, 2), "latest"],
+        "bulk_cleansing": [True],
         "api_processes": [None]
         if sys.platform not in ["linux2", "linux"]
         else [2, 20, None, "max"],
         "api_limit": [15, None],
-        "api_date": [None, datetime(2022, 2, 2), "latest"],
         "api_chunksize": [20],
         "api_data_types": [
             ["unit_data", "eeg_data", "kwk_data", "permit_data"],
@@ -62,7 +87,7 @@ def parameter_dict_working():
             None,
         ],
     }
-    return parameter_dict
+    return [parameter_dict_bulk, parameter_dict_API]
 
 
 @pytest.fixture
@@ -70,11 +95,10 @@ def parameter_dict_not_working():
     parameter_dict = {
         "method": [5, "BULK", "api"],
         "data": ["wint", "Solar", "biomasse", 5, []],
-        "bulk_date_string": [124, "heute", 123],
+        "date": [124, "heute", 123],
         "bulk_cleansing": ["cleansing", 4, None],
         "api_processes": ["20", "None"],
         "api_limit": ["15", "None"],
-        "api_date": ["None", "20220202"],
         "api_chunksize": ["20"],
         "api_data_types": ["unite_data", 5, []],
         "api_location_types": ["locatione_elec_generation", 5, []],
@@ -82,104 +106,100 @@ def parameter_dict_not_working():
     return parameter_dict
 
 
-def test_Mastr_validate_working_parameter(parameter_dict_working):
-    parameter_dict = {}
-    for key in list(parameter_dict_working.keys()):
-        parameter_dict[key] = parameter_dict_working[key][0]
+def test_Mastr_validate_working_parameter(parameter_dict_working_list):
+    for parameter_dict_working in parameter_dict_working_list:
+        parameter_dict = {
+            key: parameter_dict_working[key][0] for key in parameter_dict_working
+        }
 
-    # working parameters
-    for key in list(parameter_dict_working.keys()):
-        for value in parameter_dict_working[key]:
-            parameter_dict[key] = value
-            (
-                method,
-                data,
-                bulk_date_string,
-                bulk_cleansing,
-                api_processes,
-                api_limit,
-                api_date,
-                api_chunksize,
-                api_data_types,
-                api_location_types,
-            ) = get_parameters_from_parameter_dict(parameter_dict)
-
-            assert (
-                validate_parameter_format_for_download_method(
+        # working parameters
+        for key in list(parameter_dict_working.keys()):
+            for value in parameter_dict_working[key]:
+                parameter_dict[key] = value
+                (
                     method,
                     data,
-                    bulk_date_string,
+                    date,
                     bulk_cleansing,
                     api_processes,
                     api_limit,
-                    api_date,
                     api_chunksize,
                     api_data_types,
                     api_location_types,
+                ) = get_parameters_from_parameter_dict(parameter_dict)
+
+                assert (
+                    validate_parameter_format_for_download_method(
+                        method,
+                        data,
+                        date,
+                        bulk_cleansing,
+                        api_processes,
+                        api_limit,
+                        api_chunksize,
+                        api_data_types,
+                        api_location_types,
+                    )
+                    is None
                 )
-                is None
-            )
 
 
 def test_Mastr_validate_not_working_parameter(
-    parameter_dict_working, parameter_dict_not_working
+    parameter_dict_working_list, parameter_dict_not_working
 ):
-    parameter_dict_initial = {}
-    for key in list(parameter_dict_working.keys()):
-        parameter_dict_initial[key] = parameter_dict_working[key][0]
+    for parameter_dict_working in parameter_dict_working_list:
+        parameter_dict_initial = {
+            key: parameter_dict_working[key][0] for key in parameter_dict_working
+        }
 
-    # not working parameters
-    for key in list(parameter_dict_not_working.keys()):
-        for value in parameter_dict_not_working[key]:
-            # reset parameter_dict so that all parameters are working except one
-            parameter_dict = parameter_dict_initial.copy()
-            parameter_dict[key] = value
-            (
-                method,
-                data,
-                bulk_date_string,
-                bulk_cleansing,
-                api_processes,
-                api_limit,
-                api_date,
-                api_chunksize,
-                api_data_types,
-                api_location_types,
-            ) = get_parameters_from_parameter_dict(parameter_dict)
-            with pytest.raises(ValueError):
-                validate_parameter_format_for_download_method(
+        # not working parameters
+        for key in list(parameter_dict_not_working.keys()):
+            for value in parameter_dict_not_working[key]:
+                # reset parameter_dict so that all parameters are working except one
+                parameter_dict = parameter_dict_initial.copy()
+                parameter_dict[key] = value
+                (
                     method,
                     data,
-                    bulk_date_string,
+                    date,
                     bulk_cleansing,
                     api_processes,
                     api_limit,
-                    api_date,
                     api_chunksize,
                     api_data_types,
                     api_location_types,
-                )
+                ) = get_parameters_from_parameter_dict(parameter_dict)
+                with pytest.raises(ValueError):
+                    validate_parameter_format_for_download_method(
+                        method,
+                        data,
+                        date,
+                        bulk_cleansing,
+                        api_processes,
+                        api_limit,
+                        api_chunksize,
+                        api_data_types,
+                        api_location_types,
+                    )
 
 
 def get_parameters_from_parameter_dict(parameter_dict):
     method = parameter_dict["method"]
     data = parameter_dict["data"]
-    bulk_date_string = parameter_dict["bulk_date_string"]
+    date = parameter_dict["date"]
     bulk_cleansing = parameter_dict["bulk_cleansing"]
     api_processes = parameter_dict["api_processes"]
     api_limit = parameter_dict["api_limit"]
-    api_date = parameter_dict["api_date"]
     api_chunksize = parameter_dict["api_chunksize"]
     api_data_types = parameter_dict["api_data_types"]
     api_location_types = parameter_dict["api_location_types"]
     return (
         method,
         data,
-        bulk_date_string,
+        date,
         bulk_cleansing,
         api_processes,
         api_limit,
-        api_date,
         api_chunksize,
         api_data_types,
         api_location_types,
@@ -198,7 +218,7 @@ def test_validate_parameter_format_for_mastr_init(db):
             validate_parameter_format_for_mastr_init(engine)
 
 
-def test_transform_data_parameter(parameter_dict_working):
+def test_transform_data_parameter():
     (data, api_data_types, api_location_types, harm_log,) = transform_data_parameter(
         method="API",
         data=["wind", "location"],
@@ -208,12 +228,7 @@ def test_transform_data_parameter(parameter_dict_working):
 
     assert data == ["wind"]
     assert api_data_types == ["eeg_data"]
-    assert api_location_types == [
-        "location_elec_generation",
-        "location_elec_consumption",
-        "location_gas_generation",
-        "location_gas_consumption",
-    ]  # TODO centralize
+    assert api_location_types == API_LOCATION_TYPES
     assert harm_log == ["location"]
 
 


### PR DESCRIPTION
* bulk_date_string and api_date are removed and date parameter is introduced.
* Changes only on the higher level, for the rest is nothing changed
* Deprecated parameter ("technology", "bulk_date_string", "api_date") are accepted via kwargs
* Documentation adapted