### PR TITLE
Add envvar section to docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ The format is inspired from [Keep a Changelog](http://keepachangelog.com/en/1.0.
 and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-## [v0.XX.X] unreleased
+## [v0.12.2] unreleased
 ### Added
 ### Changed
+- Repair the csv export [#384](https://github.com/OpenEnergyPlatform/open-MaStR/pull/384)
 ### Removed
 
 ## [v0.12.1] Patch release - 2022-11-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ### Added
 ### Changed
 - Repair the csv export [#384](https://github.com/OpenEnergyPlatform/open-MaStR/pull/384)
+- Replace numeric value in hydro_extended [#392](https://github.com/OpenEnergyPlatform/open-MaStR/pull/392)
 ### Removed
 
 ## [v0.12.1] Patch release - 2022-11-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ For each version important additions, changes and removals are listed here.
 The format is inspired from [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [v0.XX.X] unreleased
+### Added
+### Changed
+### Removed
+
 ## [v0.12.1] Patch release - 2022-11-15
 ### Added
 - Add workflows to release on PyPI and Test-PyPI [#375](https://github.com/OpenEnergyPlatform/open-MaStR/pull/375)

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -117,6 +117,12 @@ It always has the format `YYYY-MM-DD`, e.g. `2022-05-16`.
 ### 11. 🐙 Set up new development
 * Create a Pull request from `production` to `develop`
 * Create a new **unreleased section** in the `📝CHANGELOG.md`
+```
+## [v0.XX.X] unreleased
+### Added
+### Changed
+### Removed
+```
 
 ▶️ Continue the developments 🛠
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -1,4 +1,4 @@
-    ********************
+********************
 Advanced Topics
 ********************
 In the following sections, a deeper description of the package and its functionalities is given.
@@ -73,9 +73,10 @@ by the parameter `engine` in the Mastr class (see :ref:`mastr module`). The poss
         engine = create_engine("postgresql://myusername:mypassword@localhost/mydatabase"
         db = Mastr(engine=engine)
 ..
-  Resulting data of download, post-processing and analysis is saved under `$HOME/.open-MaStR/data/<data-version>`.
-  Files that are suffixed with `_raw` contain joined data retrieved during :ref:`downloading <Downloading raw data>`.
-  The structure of the data is described in :ref:`Data documentation`.
+
+Resulting data of download, post-processing and analysis is saved under `$HOME/.open-MaStR/data/<data-version>`.
+Files that are suffixed with `_raw` contain joined data retrieved during :ref:`downloading <Download>`.
+The structure of the data is described in :ref:`Data Description`.
 
 MaStR account and credentials
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -53,7 +53,8 @@ of the dump overwrite older versions.
 The data can then be written to an sql database. The type of the sql database is determined
 by the parameter `engine` in the Mastr class (see :ref:`mastr module`). The possible databases are:
 
-* sqlite: This database will be stored in `$HOME/.open-MaStR/data/sqlite`.
+* sqlite: This database will be stored in `$HOME/.open-MaStR/data/sqlite` (can be customized via the
+  :ref:`environment variable <Environment variables>` `$SQLITE_DATABASE_PATH`).
 * docker-postgres: A docker container of a PostgreSQL database. 
 * own database: The Mastr class accepts a sqlalchemy.engine.Engine object as engine which enables the user to 
   use any other desired database.
@@ -77,6 +78,22 @@ by the parameter `engine` in the Mastr class (see :ref:`mastr module`). The poss
 Resulting data of download, post-processing and analysis is saved under `$HOME/.open-MaStR/data/<data-version>`.
 Files that are suffixed with `_raw` contain joined data retrieved during :ref:`downloading <Download>`.
 The structure of the data is described in :ref:`Data Description`.
+
+Environment variables
+^^^^^^^^^^^^^^^^^^^^^
+
+There are some environment variables to customize open-MaStR:
+
+.. list-table::
+   :widths: 5 5 5
+   :header-rows: 1
+
+   * - variable
+     - description
+     - example
+   * - SQLITE_DATABASE_PATH
+     - Path to the SQLite file. This allows to use to use multiple instances of the MaStR database.
+     - `/home/mastr-rabbit/.open-MaStR/data/sqlite/open-mastr-2022-12-15.db`
 
 MaStR account and credentials
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/open_mastr/mastr.py
+++ b/open_mastr/mastr.py
@@ -322,7 +322,7 @@ class Mastr:
                 additional_tables_to_export.append(table)
             else:
                 additional_tables_to_export.extend(
-                    data_to_include_tables([table], source="export_csv")
+                    data_to_include_tables([table], mapping="export_db_tables")
                 )
 
         if technologies_to_export:

--- a/open_mastr/mastr.py
+++ b/open_mastr/mastr.py
@@ -350,4 +350,4 @@ class Mastr:
                 continue
             if not df.empty:
                 path_of_table = os.path.join(data_path, f"bnetza_mastr_{table}_raw.csv")
-                df.to_csv(path_or_buf=path_of_table, encoding="utf-16")
+                df.to_csv(path_or_buf=path_of_table, encoding="utf-8")

--- a/open_mastr/soap_api/download.py
+++ b/open_mastr/soap_api/download.py
@@ -416,7 +416,7 @@ def to_csv(df: pd.DataFrame, technology: str, chunk_number: int) -> None:
             encoding="utf-8",
         )
         log.info(
-            f"Technology csv {csv_file.split('/')[-1:]} didn't exist and was created."
+            f"Technology csv: {csv_file.split('/')[-1:]} was created."
         )
     else:
         df.to_csv(

--- a/open_mastr/soap_api/mirror.py
+++ b/open_mastr/soap_api/mirror.py
@@ -16,7 +16,7 @@ from open_mastr.utils.config import (
     get_data_version_dir,
     column_renaming,
 )
-from open_mastr.soap_api.download import MaStRDownload, flatten_dict, to_csv
+from open_mastr.soap_api.download import MaStRDownload, flatten_dict, to_csv, tqdm
 from open_mastr.utils import orm
 from open_mastr.soap_api.metadata.create import datapackage_meta_json
 from open_mastr.utils.helpers import session_scope
@@ -1281,7 +1281,7 @@ class MaStRMirror:
             # Empty the basic_units table, because it will be filled entirely from extended tables
             session.query(getattr(orm, "BasicUnit", None)).delete()
 
-            for tech in technology:
+            for tech in tqdm(technology, desc="Performing reverse backfill: "):
                 # Get the class of extended table
                 unit_data_orm = getattr(orm, self.orm_map[tech]["unit_data"], None)
                 basic_unit_column_names = [

--- a/open_mastr/soap_api/mirror.py
+++ b/open_mastr/soap_api/mirror.py
@@ -1281,7 +1281,7 @@ class MaStRMirror:
             # Empty the basic_units table, because it will be filled entirely from extended tables
             session.query(getattr(orm, "BasicUnit", None)).delete()
 
-            for tech in tqdm(technology, desc="Performing reverse backfill: "):
+            for tech in tqdm(technology, desc="Performing reverse fill of basic units: "):
                 # Get the class of extended table
                 unit_data_orm = getattr(orm, self.orm_map[tech]["unit_data"], None)
                 basic_unit_column_names = [

--- a/open_mastr/utils/constants.py
+++ b/open_mastr/utils/constants.py
@@ -98,3 +98,20 @@ BULK_INCLUDE_TABLES_MAP = {
     "permit": ["einheitengenehmigung"],
     "deleted_units": ["geloeschteunddeaktivierteeinheiten"],
 }
+
+# Map bulk data to database table names, for csv export
+BULK_ADDITIONAL_TABLES_CSV_EXPORT_MAP = {
+    "gas": [
+        "gas_consumer",
+        "gas_producer",
+        "gas_storage",
+        "gas_storage_extended",
+    ],
+    "electricity_consumer": ["electricity_consumer"],
+    "location": ["locations_extended"],
+    "market": ["market_actors", "market_roles"],
+    "grid": ["grid_connections", "grids"],
+    "balancing_area": ["balancing_area"],
+    "permit": ["permit"],
+    "deleted_units": ["deleted_units"]
+}

--- a/open_mastr/utils/helpers.py
+++ b/open_mastr/utils/helpers.py
@@ -4,6 +4,7 @@ import sys
 from contextlib import contextmanager
 from datetime import date, datetime
 from warnings import warn
+from typing import Union
 
 import dateutil
 import sqlalchemy
@@ -17,6 +18,8 @@ from open_mastr.utils.constants import (
     API_DATA,
     API_DATA_TYPES,
     API_LOCATION_TYPES,
+    BULK_INCLUDE_TABLES_MAP,
+    BULK_ADDITIONAL_TABLES_CSV_EXPORT_MAP
 )
 
 
@@ -368,3 +371,38 @@ def print_api_settings(
 def validate_api_credentials() -> None:
     mastr_api = MaStRAPI()
     assert mastr_api.GetAktuellerStandTageskontingent()["Ergebniscode"] == "OK"
+
+
+def data_to_include_tables(data: list, source: str = None) -> list:
+    """
+    Convert user input 'data' to the list 'include_tables' which contains
+    file names from zipped bulk download.
+    Parameters
+    ----------
+    data: list
+        The user input for data selection
+    Returns
+    -------
+    list
+        List of file names
+    -------
+
+    """
+    if source == "write_xml":
+        # Map data selection to include tables in xml
+        include_tables = [
+            table for tech in data for table in BULK_INCLUDE_TABLES_MAP[tech]
+        ]
+        return include_tables
+    elif source == "export_csv":
+        # Map data selection to include tables in csv export
+        include_tables = [
+            table
+            for possible_data_bulk in data
+            for table in BULK_ADDITIONAL_TABLES_CSV_EXPORT_MAP[possible_data_bulk]
+        ]
+        return include_tables
+    else:
+        raise NotImplementedError(
+            "This function is only implemented for 'write_xml' and 'export_csv', please specify when calling the function."
+        )

--- a/open_mastr/utils/helpers.py
+++ b/open_mastr/utils/helpers.py
@@ -397,7 +397,8 @@ def data_to_include_tables(data: list, mapping: str = None) -> list:
             table for tech in data for table in BULK_INCLUDE_TABLES_MAP[tech]
         ]
         return include_tables
-    elif mapping == "export_db_tables":
+
+    if mapping == "export_db_tables":
         # Map data selection to include tables for csv export
         include_tables = [
             table
@@ -405,7 +406,7 @@ def data_to_include_tables(data: list, mapping: str = None) -> list:
             for table in BULK_ADDITIONAL_TABLES_CSV_EXPORT_MAP[possible_data_bulk]
         ]
         return include_tables
-    else:
-        raise NotImplementedError(
-            "This function is only implemented for 'write_xml' and 'export_db_tables', please specify when calling the function."
-        )
+
+    raise NotImplementedError(
+        "This function is only implemented for 'write_xml' and 'export_db_tables', please specify when calling the function."
+    )

--- a/open_mastr/utils/helpers.py
+++ b/open_mastr/utils/helpers.py
@@ -373,29 +373,32 @@ def validate_api_credentials() -> None:
     assert mastr_api.GetAktuellerStandTageskontingent()["Ergebniscode"] == "OK"
 
 
-def data_to_include_tables(data: list, source: str = None) -> list:
+def data_to_include_tables(data: list, mapping: str = None) -> list:
     """
-    Convert user input 'data' to the list 'include_tables' which contains
-    file names from zipped bulk download.
+    Convert user input 'data' to the list 'include_tables'.
+    It contains file names from zipped bulk download, if mapping="write_xml".
+    It contains database table names, if mapping="export_db_tables".
     Parameters
     ----------
     data: list
         The user input for data selection
+    mapping: str
+        Specify the mapping dict for the function and thus the list output.
     Returns
     -------
     list
-        List of file names
+        List of file names | List of database table names
     -------
 
     """
-    if source == "write_xml":
+    if mapping == "write_xml":
         # Map data selection to include tables in xml
         include_tables = [
             table for tech in data for table in BULK_INCLUDE_TABLES_MAP[tech]
         ]
         return include_tables
-    elif source == "export_csv":
-        # Map data selection to include tables in csv export
+    elif mapping == "export_db_tables":
+        # Map data selection to include tables for csv export
         include_tables = [
             table
             for possible_data_bulk in data
@@ -404,5 +407,5 @@ def data_to_include_tables(data: list, source: str = None) -> list:
         return include_tables
     else:
         raise NotImplementedError(
-            "This function is only implemented for 'write_xml' and 'export_csv', please specify when calling the function."
+            "This function is only implemented for 'write_xml' and 'export_db_tables', please specify when calling the function."
         )

--- a/open_mastr/xml_download/colums_to_replace.py
+++ b/open_mastr/xml_download/colums_to_replace.py
@@ -94,6 +94,7 @@ columns_replace_list = [
     "ArtDerStilllegung",
     # einheitenwasser
     "ArtDesZuflusses",
+    "ArtDerWasserkraftanlage",
     # marktrollen
     # netze
     "Sparte",

--- a/open_mastr/xml_download/utils_write_to_database.py
+++ b/open_mastr/xml_download/utils_write_to_database.py
@@ -8,7 +8,7 @@ import sqlalchemy
 from sqlalchemy import select
 from sqlalchemy.sql import text
 
-from open_mastr.utils.constants import BULK_INCLUDE_TABLES_MAP
+from open_mastr.utils.helpers import data_to_include_tables
 from open_mastr.utils.orm import tablename_mapping
 from open_mastr.xml_download.utils_cleansing_bulk import cleanse_bulk_data
 from open_mastr.utils.config import setup_logger
@@ -22,7 +22,7 @@ def write_mastr_xml_to_database(
     bulk_download_date: str,
 ) -> None:
     """Write the Mastr in xml format into a database defined by the engine parameter."""
-    include_tables = data_to_include_tables(data)
+    include_tables = data_to_include_tables(data, source="write_xml")
 
     with ZipFile(zipped_xml_file_path, "r") as f:
         files_list = f.namelist()
@@ -374,23 +374,3 @@ def handle_xml_syntax_error(data: bytes, err: Error) -> pd.DataFrame:
     return df
 
 
-def data_to_include_tables(
-    data: list,
-) -> list:
-    """
-    Convert user input 'data' to the list 'include_tables' which contains
-    file names from zipped bulk download.
-    Parameters
-    ----------
-    data: list
-        The user input for data selection
-    Returns
-    -------
-    list
-        List of file names
-    -------
-
-    """
-    # Map data selection to include tables
-    include_tables = [table for tech in data for table in BULK_INCLUDE_TABLES_MAP[tech]]
-    return include_tables

--- a/open_mastr/xml_download/utils_write_to_database.py
+++ b/open_mastr/xml_download/utils_write_to_database.py
@@ -22,7 +22,7 @@ def write_mastr_xml_to_database(
     bulk_download_date: str,
 ) -> None:
     """Write the Mastr in xml format into a database defined by the engine parameter."""
-    include_tables = data_to_include_tables(data, source="write_xml")
+    include_tables = data_to_include_tables(data, mapping="write_xml")
 
     with ZipFile(zipped_xml_file_path, "r") as f:
         files_list = f.namelist()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -3,7 +3,8 @@ from open_mastr.utils.helpers import (
     validate_parameter_format_for_download_method,
     validate_parameter_format_for_mastr_init,
     validate_api_credentials,
-    transform_data_parameter, data_to_include_tables,
+    transform_data_parameter,
+    data_to_include_tables,
 )
 import pytest
 import sys
@@ -249,9 +250,26 @@ def test_data_to_include_tables():
     map_to_db_table_list = ["market_actors", "market_roles"]
     map_to_db_table_str = ["locations_extended"]
 
-
     # Assert
-    assert include_tables_list == data_to_include_tables(data=["wind", "hydro"], mapping="write_xml")
-    assert include_tables_str == data_to_include_tables(data=["electricity_consumer"], mapping="write_xml")
-    assert map_to_db_table_list == data_to_include_tables(data=["market"], mapping="export_db_tables")
-    assert map_to_db_table_str == data_to_include_tables(data=["location"], mapping="export_db_tables")
+    assert include_tables_list == data_to_include_tables(
+        data=["wind", "hydro"], mapping="write_xml"
+    )
+    assert include_tables_str == data_to_include_tables(
+        data=["electricity_consumer"], mapping="write_xml"
+    )
+    assert map_to_db_table_list == data_to_include_tables(
+        data=["market"], mapping="export_db_tables"
+    )
+    assert map_to_db_table_str == data_to_include_tables(
+        data=["location"], mapping="export_db_tables"
+    )
+
+
+
+def test_data_to_include_tables_error():
+    # test for non-existent 'mapping' parameter input
+    with pytest.raises(
+        NotImplementedError,
+        match="This function is only implemented for 'write_xml' and 'export_db_tables', please specify when calling the function.",
+    ):
+        data_to_include_tables(data=["wind", "hydro"], mapping="X32J_22")

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -3,7 +3,7 @@ from open_mastr.utils.helpers import (
     validate_parameter_format_for_download_method,
     validate_parameter_format_for_mastr_init,
     validate_api_credentials,
-    transform_data_parameter,
+    transform_data_parameter, data_to_include_tables,
 )
 import pytest
 import sys
@@ -234,3 +234,24 @@ def test_transform_data_parameter():
 
 def test_validate_api_credentials():
     validate_api_credentials()
+
+
+def test_data_to_include_tables():
+    # Prepare
+    include_tables_list = [
+        "anlageneegwind",
+        "einheitenwind",
+        "anlageneegwasser",
+        "einheitenwasser",
+    ]
+    include_tables_str = ["einheitenstromverbraucher"]
+
+    map_to_db_table_list = ["market_actors", "market_roles"]
+    map_to_db_table_str = ["locations_extended"]
+
+
+    # Assert
+    assert include_tables_list == data_to_include_tables(data=["wind", "hydro"], mapping="write_xml")
+    assert include_tables_str == data_to_include_tables(data=["electricity_consumer"], mapping="write_xml")
+    assert map_to_db_table_list == data_to_include_tables(data=["market"], mapping="export_db_tables")
+    assert map_to_db_table_str == data_to_include_tables(data=["location"], mapping="export_db_tables")

--- a/tests/xml_download/test_utils_write_to_database.py
+++ b/tests/xml_download/test_utils_write_to_database.py
@@ -11,8 +11,8 @@ from open_mastr.xml_download.utils_write_to_database import (
     add_table_to_database,
     add_zero_as_first_character_for_too_short_string,
     correct_ordering_of_filelist,
-    data_to_include_tables,
 )
+from open_mastr.utils.helpers import data_to_include_tables
 import os
 from os.path import expanduser
 import sqlite3

--- a/tests/xml_download/test_utils_write_to_database.py
+++ b/tests/xml_download/test_utils_write_to_database.py
@@ -12,7 +12,6 @@ from open_mastr.xml_download.utils_write_to_database import (
     add_zero_as_first_character_for_too_short_string,
     correct_ordering_of_filelist,
 )
-from open_mastr.utils.helpers import data_to_include_tables
 import os
 from os.path import expanduser
 import sqlite3
@@ -238,16 +237,3 @@ def test_cast_date_columns_to_datetime():
     )
 
 
-def test_data_to_include_tables():
-    # Prepare
-    include_tables_list = [
-        "anlageneegwind",
-        "einheitenwind",
-        "anlageneegwasser",
-        "einheitenwasser",
-    ]
-    include_tables_str = ["einheitenstromverbraucher"]
-
-    # Assert
-    assert include_tables_list == data_to_include_tables(data=["wind", "hydro"])
-    assert include_tables_str == data_to_include_tables(data=["electricity_consumer"])


### PR DESCRIPTION
This PR adds a short section on env variables to the docs.

Motivation: I'd like to have multiple DBs in parallel and setting the env var `SQLITE_DATABASE_PATH` seems to be the only way at the moment. I would like to find it in the docs.