### PR TITLE
Fix 395 db conn handling during db write errors (SQLA 2.0 compatibility)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ### Changed
 - Repair the csv export [#384](https://github.com/OpenEnergyPlatform/open-MaStR/pull/384)
 - Replace numeric value in hydro_extended [#392](https://github.com/OpenEnergyPlatform/open-MaStR/pull/392)
+- Fix DB query errors when using SQLAlchemy v2.0 [#399](https://github.com/OpenEnergyPlatform/open-MaStR/pull/399)
 ### Removed
 
 ## [v0.12.1] Patch release - 2022-11-15


### PR DESCRIPTION
Fixes #395 

This fix allow to run open-mastr with SQLAlchemy v2.0 by explicitly creating a connection at some places (also works with <2.0).
It works out (tested with full run from scratch) but is not be understood as a general migration to SQLA v2.0. For the latter, the entire codebase should be re-checked (which needs quite some time I cannot afford).

As possible alternative, the version could be restricted to `<2.0` which will cause trouble in the long run but may be ok for now..

What do you think, how shall we proceed?

PS: I did not find a section "Unreleased" or sth. in the changelog to document this fix..