### PR TITLE
Feature 406 bump2version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,22 @@
+[bumpversion]
+current_version = 0.12.1
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>(a|na))+(?P<build>\d+))?
+serialize =
+	{major}.{minor}.{patch}{release}{build}
+	{major}.{minor}.{patch}
+
+[bumpversion:part:release]
+first_value = a
+optional_value = na
+values =
+	a
+	na
+
+[bumpversion:part:build]
+first_value = 1
+
+[bumpversion:file:setup.py]
+
+[bumpversion:file:./.github/workflows/ci-production.yml]
+
+[bumpversion:file:CITATION.cff]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 
 ## [v0.12.2] unreleased
 ### Added
+- Update version number with bump2version [#407](https://github.com/OpenEnergyPlatform/open-MaStR/pull/407)
 ### Changed
 - Repair the csv export [#384](https://github.com/OpenEnergyPlatform/open-MaStR/pull/384)
 - Replace numeric value in hydro_extended [#392](https://github.com/OpenEnergyPlatform/open-MaStR/pull/392)

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -59,6 +59,8 @@ It always has the format `YYYY-MM-DD`, e.g. `2022-05-16`.
 
 ### 5. 💠 Create a `release` branch
 * Checkout `develop` and branch with `git checkout -b release-v0.12.1`
+* Update version for test release with e.g. `bump2version patch`
+* Commit version update with `git commit -am "version update v0.12.1a1"`
 * Push branch with `git push --set-upstream origin release-v0.12.1`
 
 ### 6. Check release on Test-PyPI 
@@ -66,9 +68,9 @@ It always has the format `YYYY-MM-DD`, e.g. `2022-05-16`.
 * Check if the release it correctly displayed on [Test-PyPI](https://test.pypi.org/project/open-mastr/#history)
 * With each push to the release branch or the branch `test-release` the package is released on [Test-PyPI](https://test.pypi.org/project/open-mastr/#history) by GitHub workflow (test-pypi-publish.yml).
   * Note: Pre-releases on Test-PyPI are only shown under `Release history` in the navigation bar.
-  * Note: The branch status can only be released to a version on Test-PyPI once. Thus, for every branch status that you want to see on Test-PyPI you'll need to increase the version in `📝setup.py` to a number that has not been released on Test-PyPI yet, otherwise the workflow fails. Use alpha-versioning, e.g. `v0.12.1a1`, `v0.12.1a2`,...
-* Once testing on Test-PyPI is done, change the release version to the final desired version in `📝setup.py`, e.g. `v0.12.1`
-  * Note: The release on Test-PyPI might fail but it will be the correct release version for the PyPI server.
+  * Note: The branch status can only be released to a version on Test-PyPI once. Thus, for every branch status that you want to see on Test-PyPI increment the build version with `bump2version build` and push afterwards.
+* Once testing on Test-PyPI is done, change the release version to the final desired version with `bump2version release`
+  * Note: The release on Test-PyPI might fail, but it will be the correct release version for the PyPI server.
 
 ### 7. 📝 Update the version files
 * `📝CHANGELOG.md`
@@ -76,13 +78,7 @@ It always has the format `YYYY-MM-DD`, e.g. `2022-05-16`.
     * Add a new section with correct version number
     * Give the suitable name to the release
 * `📝CITATION.cff`
-    * Update the version number
     * Update `date-released`
-* `📝setup.py`
-    * Update `version`
-    * Update `download_url` (.../v0.12.1.tar.gz)
-* `📝ci-production.yml`
-    * Update version number in `run` command (line 36)
 
 ### 8. 🐙 Create a `Release Pull Request`
 * Use `📝PR_TEMPLATE_RELEASE` (❗ToDo❗)

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
             "pytest-dependency",
             "xmltodict",
             "pre-commit",
+            "bump2version",
         ]
     },
     package_data={


### PR DESCRIPTION
bump2version allows for version increment in the selected files with respect to semantic versioning, which is configured in `.bumpversion.cfg` . It basically looks for the match of current version and replaces it with the new version number.This resolves the versioning in `setup.py`, `ci-production-yml`, `CITATION.cff` and is extendable for other files. The feature must be tested manually, since no unit test exists. We should also test the release procedure at the next release.

Few examples which can be run locally:
- (`command`: current version -> new version)
- `bump2version patch`: 0.12.1 -> 0.12.2a1
- `bump2version minor`: 0.12.1 -> 0.13.0a1
- `bump2version build`: 0.12.2a1 -> 0.12.2a2
- `bump2version release`: 0.12.2a2 -> 0.12.2

Note: The tool also requires an up-to-date git repo without uncommited changes.
Resolves #382, #406