### PR TITLE
Allow schema in postgres #430

### DIFF
--- a/open_mastr/mastr.py
+++ b/open_mastr/mastr.py
@@ -1,4 +1,5 @@
 import os
+import sqlalchemy
 
 # import xml dependencies
 from open_mastr.xml_download.utils_download_bulk import download_xml_Mastr
@@ -28,17 +29,18 @@ from open_mastr.utils.config import (
     get_data_version_dir,
     get_project_home_dir,
     get_output_dir,
-    setup_logger
+    setup_logger,
 )
 import open_mastr.utils.orm as orm
 
 # import initialize_database dependencies
 from open_mastr.utils.helpers import (
     create_database_engine,
+    create_database_schema,
 )
 
 # constants
-from open_mastr.utils.constants import TECHNOLOGIES, ADDITIONAL_TABLES
+from open_mastr.utils.constants import TECHNOLOGIES, ADDITIONAL_TABLES, DATABASE_SCHEMA
 
 # setup logger
 log = setup_logger()
@@ -80,7 +82,7 @@ class Mastr:
             "delete the database and update the package by running "
             "'pip install --upgrade open-mastr'\n"
         )
-
+        create_database_schema(self.engine)
         orm.Base.metadata.create_all(self.engine)
 
     def download(

--- a/open_mastr/utils/constants.py
+++ b/open_mastr/utils/constants.py
@@ -197,3 +197,5 @@ UNIT_TYPE_MAP = {
     "Gaserzeugungslokation": "location_gas_generation",
     "Gasverbrauchslokation": "location_gas_consumption",
 }
+
+DATABASE_SCHEMA = "mastr"

--- a/open_mastr/utils/orm.py
+++ b/open_mastr/utils/orm.py
@@ -12,8 +12,9 @@ from sqlalchemy import (
     Date,
     JSON,
 )
+from open_mastr.utils.constants import DATABASE_SCHEMA
 
-meta = MetaData()
+meta = MetaData(schema=DATABASE_SCHEMA)
 Base = declarative_base(metadata=meta)
 
 


### PR DESCRIPTION
For the bulk download, if the engine comes from a postgres database, the data is now written to the schema specified in constants. Right now this does not work for the API.

### PR-Assignee
- [ ] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CHANGELOG.md)
- [ ] 📙 Update the documentation

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
