### PR TITLE
Feature 449 existing date parameter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,4 @@ repos:
     rev: 22.6.0
     hooks:
       - id: black
-        language_version: python3.9
+        language_version: python3.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ## [v0.1X.X] current  - 2023-XX-XX
 ### Added
 - User-defined output path for csv, xml, database [#402](https://github.com/OpenEnergyPlatform/open-MaStR/pull/402)
+- Add date=existing parameter to Mastr.download [#452](https://github.com/OpenEnergyPlatform/open-MaStR/pull/452)
 ### Changed
 ### Removed
 - Delete `on push` for github workflow [#445](https://github.com/OpenEnergyPlatform/open-MaStR/pull/445)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx>=2
+sphinx<7
 sphinx-rtd-theme
 sphinx-tabs
 m2r2

--- a/open_mastr/mastr.py
+++ b/open_mastr/mastr.py
@@ -28,7 +28,7 @@ from open_mastr.utils.config import (
     get_data_version_dir,
     get_project_home_dir,
     get_output_dir,
-    setup_logger
+    setup_logger,
 )
 import open_mastr.utils.orm as orm
 
@@ -65,7 +65,6 @@ class Mastr:
     """
 
     def __init__(self, engine="sqlite") -> None:
-
         validate_parameter_format_for_mastr_init(engine)
         self.output_dir = get_output_dir()
         self.home_directory = get_project_home_dir()
@@ -143,7 +142,7 @@ class Mastr:
             Either "today" or None if the newest data dump should be downloaded
             rom the MaStR website. If an already downloaded dump should be used,
             state the date of the download in the format
-            "yyyymmdd". Defaults to None.
+            "yyyymmdd" or use the string "existing". Defaults to None.
 
             For API method:
 
@@ -215,10 +214,9 @@ class Mastr:
             method, data, api_data_types, api_location_types, **kwargs
         )
 
-        date = transform_date_parameter(method, date, **kwargs)
+        date = transform_date_parameter(self, method, date, **kwargs)
 
         if method == "bulk":
-
             # Find the name of the zipped xml folder
             bulk_download_date = parse_date_string(date)
             xml_folder_path = os.path.join(self.output_dir, "data", "xml_download")
@@ -349,7 +347,6 @@ class Mastr:
 
         # Export technologies to csv
         for tech in technologies_to_export:
-
             db_query_to_csv(
                 db_query=create_db_query(tech=tech, limit=limit, engine=self.engine),
                 data_table=tech,
@@ -357,7 +354,6 @@ class Mastr:
             )
         # Export additional tables to csv
         for addit_table in additional_tables_to_export:
-
             db_query_to_csv(
                 db_query=create_db_query(
                     additional_table=addit_table, limit=limit, engine=self.engine

--- a/open_mastr/utils/helpers.py
+++ b/open_mastr/utils/helpers.py
@@ -1,39 +1,38 @@
-import os
 import json
+import os
 import sys
 from contextlib import contextmanager
 from datetime import date, datetime
 from warnings import warn
 
 import dateutil
+import pandas as pd
 import sqlalchemy
-from sqlalchemy.sql import insert, literal_column
 from dateutil.parser import parse
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Query, sessionmaker
-
-import pandas as pd
+from sqlalchemy.sql import insert, literal_column
 from tqdm import tqdm
+
+from open_mastr.soap_api.download import MaStRAPI, log
 from open_mastr.soap_api.metadata.create import create_datapackage_meta_json
 from open_mastr.utils import orm
 from open_mastr.utils.config import (
-    get_filenames,
-    get_data_version_dir,
     column_renaming,
+    get_data_version_dir,
+    get_filenames,
 )
-
-from open_mastr.soap_api.download import MaStRAPI, log
 from open_mastr.utils.constants import (
-    BULK_DATA,
-    TECHNOLOGIES,
+    ADDITIONAL_TABLES,
     API_DATA,
     API_DATA_TYPES,
     API_LOCATION_TYPES,
-    BULK_INCLUDE_TABLES_MAP,
     BULK_ADDITIONAL_TABLES_CSV_EXPORT_MAP,
+    BULK_DATA,
+    BULK_INCLUDE_TABLES_MAP,
     ORM_MAP,
+    TECHNOLOGIES,
     UNIT_TYPE_MAP,
-    ADDITIONAL_TABLES,
 )
 
 
@@ -307,11 +306,13 @@ def transform_date_parameter(self, method, date, **kwargs):
             if not existing_files_list:
                 date = "today"
                 print(
-                    "By choosing `date`='existing' you want to use an existing xml download."
+                    "By choosing `date`='existing' you want to use an existing "
+                    "xml download."
                     "However no xml_files were downloaded yet. The parameter `date` is"
-                    "therefore set to 'latest'."
+                    "therefore set to 'today'."
                 )
-            # we assume that there is only one file in the folder which is the zipped xml folder
+            # we assume that there is only one file in the folder which is the
+            # zipped xml folder
             date = existing_files_list[0].split("_")[1].split(".")[0]
     elif method == "API":
         date = kwargs.get("api_date", date)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -70,7 +70,7 @@ def parameter_dict_working_list():
             None,
             ["wind", "solar"],
         ],
-        "date": ["today", "20200108"],
+        "date": ["today", "20200108", "existing"],
         "bulk_cleansing": [True, False],
         "api_processes": [None],
         "api_limit": [50],


### PR DESCRIPTION
## Summary of the discussion

The parameter `date`="existing" should use the already downloaded xml files.

## Type of change (CHANGELOG.md)


### Updated
- `date` = "existing" was introduced for the bulk download
- 

## Workflow checklist

### Automation
Closes #449 

### PR-Assignee
- [ ] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CHANGELOG.md)
- [x] 📙 Update the documentation

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
