### PR TITLE
remove webscraping for URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ### Added
 ### Changed
 - Fix and add URLs of example projects in readme [#481](https://github.com/OpenEnergyPlatform/open-MaStR/pull/481)
-- No longer require web scraping for bulk download [#485](https://github.com/OpenEnergyPlatform/open-MaStR/pull/488)
+- No longer require web scraping for bulk download [#488](https://github.com/OpenEnergyPlatform/open-MaStR/pull/488)
 ### Removed
 
 ## [v0.14.1] Hotfix - 2024-01-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ## [v0.XX.X] unreleased - 2024-XX-XX
 ### Added
 ### Changed
-- Fix and add URLs of example projects in readme [#481]((https://github.com/OpenEnergyPlatform/open-MaStR/pull/481)
+- Fix and add URLs of example projects in readme [#481](https://github.com/OpenEnergyPlatform/open-MaStR/pull/481)
+- No longer require web scraping for bulk download [#485](https://github.com/OpenEnergyPlatform/open-MaStR/pull/488)
 ### Removed
 
 ## [v0.14.1] Hotfix - 2024-01-17

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(
         "requests",
         "keyring",
         "tqdm",
-        "beautifulsoup4",
         "pyyaml",
         "xmltodict",
     ],

--- a/tests/xml_download/test_utils_download_bulk.py
+++ b/tests/xml_download/test_utils_download_bulk.py
@@ -1,8 +1,33 @@
-from open_mastr.xml_download.utils_download_bulk import get_url_from_Mastr_website
+import time
+from open_mastr.xml_download.utils_download_bulk import gen_url
 
-
-def test_get_url_from_Mastr_website():
-    url = get_url_from_Mastr_website()
-    assert len(url) > 10
+def test_gen_url():
+    when = time.strptime("2024-01-01", "%Y-%m-%d")
+    url = gen_url(when)
     assert type(url) == str
-    assert "marktstammdaten" in url
+    assert url == "https://download.marktstammdatenregister.de/Gesamtdatenexport_20240101_23.2.zip"
+
+    when = time.strptime("2024-04-01", "%Y-%m-%d")
+    url = gen_url(when)
+    assert type(url) == str
+    assert url == "https://download.marktstammdatenregister.de/Gesamtdatenexport_20240401_23.2.zip"
+
+    when = time.strptime("2024-04-02", "%Y-%m-%d")
+    url = gen_url(when)
+    assert type(url) == str
+    assert url == "https://download.marktstammdatenregister.de/Gesamtdatenexport_20240402_24.1.zip"
+
+    when = time.strptime("2024-10-01", "%Y-%m-%d")
+    url = gen_url(when)
+    assert type(url) == str
+    assert url == "https://download.marktstammdatenregister.de/Gesamtdatenexport_20241001_24.1.zip"
+
+    when = time.strptime("2024-10-02", "%Y-%m-%d")
+    url = gen_url(when)
+    assert type(url) == str
+    assert url == "https://download.marktstammdatenregister.de/Gesamtdatenexport_20241002_24.2.zip"
+
+    when = time.strptime("2024-12-31", "%Y-%m-%d")
+    url = gen_url(when)
+    assert type(url) == str
+    assert url == "https://download.marktstammdatenregister.de/Gesamtdatenexport_20241231_24.2.zip"


### PR DESCRIPTION
The URL format has been changed and no longer includes the random string. This means the web scraping with BeauitfulSoup is no longer necessary.

## Workflow checklist

### PR-Assignee
- [ ] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CHANGELOG.md)
~~📙 Update the documentation~~ no API change, not applicable

### Reviewer
- [x] 🐙 Follow the [Reviewer Guidelines](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [x] 🐙 Provided feedback and show sufficient appreciation for the work done
