### PR TITLE
add open-mastr user agent to bulk download requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ### Added
 - Extend documentation section `getting started` based on the JOSS Review [#523](https://github.com/OpenEnergyPlatform/open-MaStR/pull/523)
 ### Changed
+- Change header to identify as open-mastr during http request [#526](https://github.com/OpenEnergyPlatform/open-MaStR/pull/526)
 ### Removed
 
 ## [v0.14.3] Fix Pypi Release - 2024-04-24 


### PR DESCRIPTION
## Summary of the discussion

adds a User-Agent to the requests when doing a bulk download.
The `importlib.metadata` is available in the python core since version 3.9, so for all supported versions.

In the rare but possible case, that the `open-mastr` module is called directly without being installed in any way, the user-agent is simply set to `open-mastr` without any version.

As all requests also contain the version of the python-requests library, this is added as well to provide metadata.

## Workflow checklist

### Automation
Closes #489

### PR-Assignee
- [ ] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CHANGELOG.md)
- [ ] 📙 Update the documentation

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
