### PR TITLE
Hotfix 533 xml download yesterday misses gen url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ### Changed
 - Change License identifier for pypi [#525](https://github.com/OpenEnergyPlatform/open-MaStR/pull/525)
 - Change header to identify as open-mastr during http request [#526](https://github.com/OpenEnergyPlatform/open-MaStR/pull/526)
-- Fixed missing call to gen_url in case first bulk download fails as xml file for today is not yet available [#533]
+- Fixed missing call to gen_url in case first bulk download fails as xml file for today is not yet available [#534](https://github.com/OpenEnergyPlatform/open-MaStR/pull/534)
 ### Removed
 
 ## [v0.14.3] Fix Pypi Release - 2024-04-24 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ### Changed
 - Change License identifier for pypi [#525](https://github.com/OpenEnergyPlatform/open-MaStR/pull/525)
 - Change header to identify as open-mastr during http request [#526](https://github.com/OpenEnergyPlatform/open-MaStR/pull/526)
+- Fixed missing call to gen_url in case first bulk download fails as xml file for today is not yet available [#533]
 ### Removed
 
 ## [v0.14.3] Fix Pypi Release - 2024-04-24 

--- a/open_mastr/xml_download/utils_download_bulk.py
+++ b/open_mastr/xml_download/utils_download_bulk.py
@@ -128,6 +128,7 @@ def download_xml_Mastr(
         # presumably todays download is not ready yet, retry with yesterdays date
         log.warning("Download file was not found. Assuming that the new file was not published yet and retrying with yesterday.")
         now = time.localtime(time.mktime(now) - (24 * 60 * 60)) # subtract 1 day from the date
+        url = gen_url(now) # generate URL for 'yesterday'
         r = requests.get(url, stream=True, headers={"User-Agent": USER_AGENT})
     if r.status_code == 404:
         log.error("Could not download file: download URL not found")

--- a/open_mastr/xml_download/utils_download_bulk.py
+++ b/open_mastr/xml_download/utils_download_bulk.py
@@ -12,7 +12,9 @@ from tqdm import tqdm
 from open_mastr.utils.config import setup_logger
 
 try:
-    USER_AGENT = f"open-mastr/{version('open-mastr')} python-requests/{version('requests')}"
+    USER_AGENT = (
+        f"open-mastr/{version('open-mastr')} python-requests/{version('requests')}"
+    )
 except PackageNotFoundError:
     USER_AGENT = "open-mastr"
 log = setup_logger()
@@ -58,7 +60,8 @@ def gen_version(when: time.struct_time = time.localtime()) -> str:
     # only the last two digits of the year are used
     year = str(year)[-2:]
 
-    return f'{year}.{release}'
+    return f"{year}.{release}"
+
 
 def gen_url(when: time.struct_time = time.localtime()) -> str:
     """
@@ -77,7 +80,7 @@ def gen_url(when: time.struct_time = time.localtime()) -> str:
     version = gen_version(when)
     date = time.strftime("%Y%m%d", when)
 
-    return f'https://download.marktstammdatenregister.de/Gesamtdatenexport_{date}_{version}.zip'
+    return f"https://download.marktstammdatenregister.de/Gesamtdatenexport_{date}_{version}.zip"
 
 
 def download_xml_Mastr(
@@ -125,19 +128,23 @@ def download_xml_Mastr(
     time_a = time.perf_counter()
     r = requests.get(url, stream=True, headers={"User-Agent": USER_AGENT})
     if r.status_code == 404:
-        # presumably todays download is not ready yet, retry with yesterdays date
-        log.warning("Download file was not found. Assuming that the new file was not published yet and retrying with yesterday.")
-        now = time.localtime(time.mktime(now) - (24 * 60 * 60)) # subtract 1 day from the date
-        url = gen_url(now) # generate URL for 'yesterday'
+        log.warning(
+            "Download file was not found. Assuming that the new file was not published yet and retrying with yesterday."
+        )
+        now = time.localtime(
+            time.mktime(now) - (24 * 60 * 60)
+        )  # subtract 1 day from the date
+        url = gen_url(now)
         r = requests.get(url, stream=True, headers={"User-Agent": USER_AGENT})
     if r.status_code == 404:
         log.error("Could not download file: download URL not found")
         return
 
     total_length = int(18000 * 1024 * 1024)
-    with open(save_path, "wb") as zfile, tqdm(
-        desc=save_path, total=(total_length / 1024 / 1024), unit=""
-    ) as bar:
+    with (
+        open(save_path, "wb") as zfile,
+        tqdm(desc=save_path, total=(total_length / 1024 / 1024), unit="") as bar,
+    ):
         for chunk in r.iter_content(chunk_size=1024 * 1024):
             # chunk size of 1024 * 1024 needs 9min 11 sek = 551sek
             # chunk size of 1024 needs 9min 11 sek as well


### PR DESCRIPTION
If accpeted, this commit will close issue #533 by adding the missing call to gen_url in open_mastr/xml_download/utils_download_bulk.py

## Workflow checklist

### Automation
Close #533

### PR-Assignee
- [ ] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CHANGELOG.md)
- [ ] 📙 Update the documentation

### Reviewer
- [x] 🐙 Follow the [Reviewer Guidelines](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [x] 🐙 Provided feedback and show sufficient appreciation for the work done
