### PR TITLE
Fix 549 docs on user defined output path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ### Added
 ### Changed
 - Fix usercff workflow [#545](https://github.com/OpenEnergyPlatform/open-MaStR/issues/544)
+- Fix docs on user-defined output path for csv, xml, database
+  [#549](https://github.com/OpenEnergyPlatform/open-MaStR/issues/549)
 ### Removed
 
 ## [v0.14.4] Release for the Journal of Open Source Software JOSS - 2024-06-07

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -25,6 +25,11 @@ authors:
     alias: "@deniztepe"
     affiliation: "fortiss"
     orcid: " https://orcid.org/0000-0002-7605-0173"
+  - family-names: "Amme"
+    given-names: "Jonathan"
+    alias: "@nesnoj"
+    affiliation: "Reiner Lemoine Institut"
+    orcid: " https://orcid.org/0000-0002-8563-5261"
 title: "open-MaStR"
 type: software
 license: AGPL-3.0

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -28,6 +28,7 @@ The possible databases are:
 ### Project directory
 
 The directory `$HOME/.open-MaStR` is automatically created. It is used to store configuration files and save data.
+You can change this default path, see [environment variables](#environment-variables).
 Default config files are copied to this directory which can be modified - but with caution.
 The project home directory is structured as follows (files and folders below `data/` just an example).
 
@@ -86,6 +87,15 @@ The data can then be written to any sql database supported by [sqlalchemy](https
 
 For more information regarding the database see [Database settings](#database-settings).
 
+
+### Environment variables
+
+There are some environment variables to customize open-MaStR:
+
+| Variable               | Description                                                                                                                                                              | Example                                                                                                                    |
+|------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
+| `SQLITE_DATABASE_PATH` | Path to the SQLite file. This allows to use to use multiple instances of the MaStR database. The database instances exist in parallel and are independent of each other. | `/home/mastr-rabbit/.open-MaStR/data/sqlite/your_custom_instance_name.db`                                                  |
+| `OUTPUT_PATH`          | Path to user-defined output directory for CSV data, XML file and database. If not specified, output directory defaults to `$HOME/.open-MaStR/`                           | Linux: `/home/mastr-rabbit/open-mastr-user-defined-output-path`, Windows: `C:\\Users\\open-mastr-user-defined-output-path` |
 
 ## Bulk download
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,13 +25,15 @@ authors = [
   {name = "Muschner Christoph"},
   {name = "Kotthoff Florian"},
   {name = "Tepe Deniz"},
+  {name = "Amme Jonathan"},
   {name = "Open Energy Family"},
 ]
 
 maintainers = [
   {name = "Ludwig Hülk", email = "datenzentrum@rl-institut.de"},
   {name = "Florian Kotthoff"},
-  {name = "Christoph Muschner", email = "datenzentrum@rl-institut.de"}  
+  {name = "Christoph Muschner", email = "datenzentrum@rl-institut.de"},
+  {name = "Jonathan Amme", email = "jonathan.amme@rl-institut.de"}
 ]
 description = "A package that provides an interface for downloading and processing the data of the Marktstammdatenregister (MaStR)"
 readme = "README.rst"


### PR DESCRIPTION
## Summary of the discussion

Re-adds instructions how to use env vars to docs.

## Type of change (CHANGELOG.md)

### Updated
- Fix docs on user-defined output path for csv, xml, database
  [#549](https://github.com/OpenEnergyPlatform/open-MaStR/issues/549)

## Workflow checklist

### Automation
Closes #549 

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CHANGELOG.md)
- [x] 📙 Update the documentation

### Reviewer
- [x] 🐙 Follow the [Reviewer Guidelines](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [x] 🐙 Provided feedback and show sufficient appreciation for the work done
