### PR TITLE
Fix 553 pandas numpy version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - Fix usercff workflow [#545](https://github.com/OpenEnergyPlatform/open-MaStR/issues/544)
 - Fix docs on user-defined output path for csv, xml, database
   [#549](https://github.com/OpenEnergyPlatform/open-MaStR/issues/549)
+- Set pandas version to >=2.2.2 for compatibility with numpy v2.0
+  [#553](https://github.com/OpenEnergyPlatform/open-MaStR/issues/553)
 ### Removed
 
 ## [v0.14.4] Release for the Journal of Open Source Software JOSS - 2024-06-07

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "open_mastr"
 version = "0.14.4"
 dependencies = [
-  "pandas>=2.1",  # pandas 2.1 is needed for dataframe.map()
+  "pandas>=2.2.2",
   "numpy",
   "sqlalchemy>=2.0",
   "psycopg2-binary",


### PR DESCRIPTION
## Summary of the discussion

Fixes compatibility issues of pandas and numpy.

## Type of change (CHANGELOG.md)

### Updated
- Set pandas version to >=2.2.2 for compatibility with numpy v2.0
  [#553](https://github.com/OpenEnergyPlatform/open-MaStR/issues/553)

## Workflow checklist

### Automation
Closes #553

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CHANGELOG.md)
- [ ] 📙 ~Update the documentation~

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
