### PR TITLE
Feature 562 export storage units

### DIFF
--- a/.github/workflows/ci-develop.yml
+++ b/.github/workflows/ci-develop.yml
@@ -11,7 +11,7 @@ jobs:
 
     # Jobs definition
     runs-on: ${{ matrix.os }}
-    if: ${{ (!github.event.pull_request.draft) || (github.event.pull_request.ready_for_review) }}
+    if: ${{ !github.event.pull_request.draft }}
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]

--- a/.github/workflows/ci-develop.yml
+++ b/.github/workflows/ci-develop.yml
@@ -11,7 +11,7 @@ jobs:
 
     # Jobs definition
     runs-on: ${{ matrix.os }}
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ (!github.event.pull_request.draft) || (github.event.pull_request.ready_for_review) }}
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
   [#553](https://github.com/OpenEnergyPlatform/open-MaStR/issues/553)
 - Allow to configure model/service port in `soap_api.download.MaStRAPI`
   [#556](https://github.com/OpenEnergyPlatform/open-MaStR/issues/556)
+- Allow CSV export of table `storage_units`
+  [#562](https://github.com/OpenEnergyPlatform/open-MaStR/issues/562)
 ### Removed
 
 ## [v0.14.4] Release for the Journal of Open Source Software JOSS - 2024-06-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - Allow to configure model/service port in `soap_api.download.MaStRAPI`
   [#556](https://github.com/OpenEnergyPlatform/open-MaStR/issues/556)
 - Allow CSV export of table `storage_units`
-  [#562](https://github.com/OpenEnergyPlatform/open-MaStR/issues/562)
+  [#565](https://github.com/OpenEnergyPlatform/open-MaStR/pull/565)
 ### Removed
 
 ## [v0.14.4] Release for the Journal of Open Source Software JOSS - 2024-06-07

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,5 +1,5 @@
 For most users, the functionalites described in [Getting Started](getting_started.md) are sufficient.  If you want 
-to examine how you can configure the package's behavior for your own needs, check out [Cofiguration](#configuration). Or you can explore the two main functionalities of the package, namely the [Bulk Download](#bulk-download)
+to examine how you can configure the package's behavior for your own needs, check out [Configuration](#configuration). Or you can explore the two main functionalities of the package, namely the [Bulk Download](#bulk-download)
 or the [SOAP API download](#soap-api-download).
 
 ## Configuration

--- a/open_mastr/mastr.py
+++ b/open_mastr/mastr.py
@@ -142,6 +142,7 @@ class Mastr:
             | "nuclear"             | Yes  | Yes  |
             | "gas"                 | Yes  | Yes  |
             | "storage"             | Yes  | Yes  |
+            | "storage_units"       | Yes  | Yes  |
             | "electricity_consumer"| Yes  | No   |
             | "location"            | Yes  | Yes  |
             | "market"              | Yes  | No   |

--- a/open_mastr/mastr.py
+++ b/open_mastr/mastr.py
@@ -304,7 +304,7 @@ class Mastr:
                 "balancing_area", "electricity_consumer", "gas_consumer", "gas_producer",
                 "gas_storage", "gas_storage_extended",
                 "grid_connections", "grids", "market_actors", "market_roles",
-                "locations_extended, 'permit', 'deleted_units' ]
+                "locations_extended", "permit", "deleted_units", "storage_units"]
         chunksize: int
             Defines the chunksize of the tables export.
             Default value is 500.000 rows to include in each chunk.

--- a/open_mastr/utils/constants.py
+++ b/open_mastr/utils/constants.py
@@ -18,6 +18,7 @@ BULK_DATA = [
     "deleted_units",
     "retrofit_units",
     "changed_dso_assignment",
+    "storage_units",
 ]
 
 # Possible values for parameter 'data' with API download method
@@ -64,6 +65,7 @@ ADDITIONAL_TABLES = [
     "deleted_units",
     "retrofit_units",
     "changed_dso_assignment",
+    "storage_units",
 ]
 
 # Possible data types for API download
@@ -181,6 +183,7 @@ ORM_MAP = {
     "deleted_units": "DeletedUnits",
     "retrofit_units": "RetrofitUnits",
     "changed_dso_assignment": "ChangedDSOAssignment",
+    "storage_units": "StorageUnits",
 }
 
 UNIT_TYPE_MAP = {

--- a/open_mastr/utils/constants.py
+++ b/open_mastr/utils/constants.py
@@ -91,7 +91,8 @@ BULK_INCLUDE_TABLES_MAP = {
     ],
     "combustion": ["anlagenkwk", "einheitenverbrennung"],
     "nuclear": ["einheitenkernkraft"],
-    "storage": ["anlageneegspeicher", "anlagenstromspeicher", "einheitenstromspeicher"],
+    "storage": ["anlageneegspeicher", "einheitenstromspeicher"],
+    "storage_units": ["anlagenstromspeicher"],
     "gas": [
         "anlagengasspeicher",
         "einheitengaserzeuger",

--- a/open_mastr/utils/constants.py
+++ b/open_mastr/utils/constants.py
@@ -162,7 +162,10 @@ ORM_MAP = {
         "eeg_data": "HydroEeg",
         "permit_data": "Permit",
     },
-    "nuclear": {"unit_data": "NuclearExtended", "permit_data": "Permit"},
+    "nuclear": {
+        "unit_data": "NuclearExtended",
+        "permit_data": "Permit"
+    },
     "storage": {
         "unit_data": "StorageExtended",
         "eeg_data": "StorageEeg",

--- a/open_mastr/utils/constants.py
+++ b/open_mastr/utils/constants.py
@@ -79,7 +79,7 @@ API_LOCATION_TYPES = [
     "location_gas_consumption",
 ]
 
-# Map bulk data to bulk download tables (xml file names)
+# Map bulk data to bulk download tables (XML file names)
 BULK_INCLUDE_TABLES_MAP = {
     "wind": ["anlageneegwind", "einheitenwind"],
     "solar": ["anlageneegsolar", "einheitensolar"],

--- a/open_mastr/utils/helpers.py
+++ b/open_mastr/utils/helpers.py
@@ -222,7 +222,7 @@ def validate_parameter_data(method, data) -> None:
                 )
             if method == "csv_export" and value not in TECHNOLOGIES + ADDITIONAL_TABLES:
                 raise ValueError(
-                    "Allowed values for parameter data with API method are "
+                    "Allowed values for CSV export are "
                     f"{TECHNOLOGIES} or {ADDITIONAL_TABLES}"
                 )
 


### PR DESCRIPTION
## Summary of the discussion

Allows CSV export of table `storage_units`

- `db.to_csv()` and `db.to_csv("storage_units")` now export to `bnetza_mastr_storage_units_raw.csv`.
- `db.download("bulk", data="storage")` does not include `storage_units`/`anlagenstromspeicher` anymore as I had to split "storage" in [`BULK_INCLUDE_TABLES_MAP`](https://github.com/OpenEnergyPlatform/open-MaStR/blob/e03e824885d4f421c30aeb7c97f59f2570bea9ef/open_mastr/utils/constants.py#L92) to allow for CSV export. Instead, if a user wants only the storage units to be written to the DB, they need to be written separately via `db.download("bulk", data="storage_units")`. I assume most users  write all data to the DB anyways (`db.download("bulk")`) which works properly.

### Updated
- Allow CSV export of table `storage_units` [#562](https://github.com/OpenEnergyPlatform/open-MaStR/issues/562)

## Workflow checklist

### Automation
Closes #562

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CHANGELOG.md)
- [ ] 📙 Update the documentation

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
