### PR TITLE
594 stop using google font for mkdocs page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
   [#587](https://github.com/OpenEnergyPlatform/open-MaStR/pull/587)
 - Update bug issue templates
   [#593](https://github.com/OpenEnergyPlatform/open-MaStR/pull/593)
+- Delete Google Fonts from Documentation Page
+  [#599](https://github.com/OpenEnergyPlatform/open-MaStR/pull/599)
 ### Removed
 - Moved old code artefacts from `scripts` folder to paper specific 
   [repository](https://github.com/FlorianK13/verify-marktstammdaten) 

--- a/docs/development/release_procedure_mirror.md
+++ b/docs/development/release_procedure_mirror.md
@@ -1,8 +1,0 @@
----
-hide:
-  - toc
----
-
-{%
-   include-markdown "../../RELEASE_PROCEDURE.md"
-%}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ theme:
     repo: fontawesome/brands/github
   logo: images/OpenEnergyFamily_Logo_OpenMaStR_no_name_white.png
   favicon: images/OpenEnergyFamily_Logo_OpenMaStR_no_name_grey.png
+  font: false
 
 plugins:
   - search

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,7 +84,6 @@ nav:
     - Advanced Usage of the MaStR SOAP-API: reference/advanced.md
   - Development: 
     - Contributing: development/contributing_mirror.md
-    - Release Procedure: development/release_procedure_mirror.md
     - Changelog: development/changelog_mirror.md
 
 repo_url: https://github.com/OpenEnergyPlatform/open-MaStR

--- a/open_mastr/mastr.py
+++ b/open_mastr/mastr.py
@@ -400,7 +400,7 @@ class Mastr:
             db.download(data='biomass')
             db.translate()
 
-            df = pd.read_sql(table='biomass_extended', con=db.engine)
+            df = pd.read_sql(sql='biomass_extended', con=db.engine)
             print(df.head(10))
             ```
 


### PR DESCRIPTION
- removed google font
- Fixed docs of `.translate` method (see #597)
- Fixed docs part that tried to import the now deleted `Release_Procedure`