### PR TITLE
Add columns from the current MaStR release 25.1.158 #607

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
   [#601](https://github.com/OpenEnergyPlatform/open-MaStR/pull/601)
 - Generate multiple download links for different MaStR versions 
   [#613](https://github.com/OpenEnergyPlatform/open-MaStR/pull/613)
+- Add new columns `WindAnLandOderAufSee,TechnologieFlugwindenergieanlage,Flughoehe,Flugradius,ArtDerSolaranlage,SpeicherAmGleichenOrt` to `columns_to_replace.py`
+  [#614](https://github.com/OpenEnergyPlatform/open-MaStR/issues/614)
 ### Removed
 - Moved old code artefacts from `scripts` folder to paper specific 
   [repository](https://github.com/FlorianK13/verify-marktstammdaten) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 - Generate multiple download links for different MaStR versions 
   [#613](https://github.com/OpenEnergyPlatform/open-MaStR/pull/613)
 - Add new columns `WindAnLandOderAufSee,TechnologieFlugwindenergieanlage,Flughoehe,Flugradius,ArtDerSolaranlage,SpeicherAmGleichenOrt` to `columns_to_replace.py`
-  [#614](https://github.com/OpenEnergyPlatform/open-MaStR/issues/614)
+  [#618](https://github.com/OpenEnergyPlatform/open-MaStR/issues/618)
 ### Removed
 - Moved old code artefacts from `scripts` folder to paper specific 
   [repository](https://github.com/FlorianK13/verify-marktstammdaten) 

--- a/open_mastr/xml_download/colums_to_replace.py
+++ b/open_mastr/xml_download/colums_to_replace.py
@@ -112,4 +112,10 @@ columns_replace_list = [
     "ClusterOstsee",
     # various tables
     "NetzbetreiberpruefungStatus",
+    "WindAnLandOderAufSee",
+    "TechnologieFlugwindenergieanlage",
+    "Flughoehe",
+    "Flugradius",
+    "ArtDerSolaranlage",
+    "SpeicherAmGleichenOrt",
 ]


### PR DESCRIPTION
## Summary of the discussion

In the newest MaStR release a few new columns were added. In order to properly map the category names, the `columns_replace_list` is updated.

## Type of change (CHANGELOG.md)

### Added
- Add new columns `WindAnLandOderAufSee,TechnologieFlugwindenergieanlage,Flughoehe,Flugradius,ArtDerSolaranlage,SpeicherAmGleichenOrt` to `columns_to_replace.py`
[#618](https://github.com/OpenEnergyPlatform/open-MaStR/issues/618)

## Workflow checklist

### Automation
Closes #607 

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CHANGELOG.md)
- [ ] 📙 Update the documentation

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
