### PR TITLE
Fix test pypi publication

### DIFF
--- a/.github/workflows/test-pypi-publish.yml
+++ b/.github/workflows/test-pypi-publish.yml
@@ -13,8 +13,6 @@ jobs:
     environment: pypi-publish
     steps:
     - uses: actions/checkout@v4
-      with:
-        ref: release
     - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ## [v0.XX.X] unreleased - 202X-XX-XX
 ### Added
 ### Changed
+- Fix package publication workflow
+  [#636](https://github.com/OpenEnergyPlatform/open-MaStR/pull/636)
 ### Removed
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
   [#621](https://github.com/OpenEnergyPlatform/open-MaStR/pull/621)
 ### Removed
 - Moved old code artefacts from `scripts` folder to paper specific
-  [repository](https://github.com/FlorianK13/verify-marktstammdaten) 
+  [repository](https://github.com/FlorianK13/verify-marktstammdaten)
   [#561](https://github.com/OpenEnergyPlatform/open-MaStR/pull/561)
 - Remove old dependencies and broken README links
   [#619](https://github.com/OpenEnergyPlatform/open-MaStR/pull/619)


### PR DESCRIPTION
Remove default branch for test pypi publication added in #631. This branch was always set on workflow trigger and the manually selected branch was ignored.

Tested successfully using manual trigger on branch `fix-612-pypi-test-publish-workflow-test` (using version 0.15.1), [see diff here](https://github.com/OpenEnergyPlatform/open-MaStR/compare/fix-612-pypi-test-publish-workflow-test):
- [Workflow](https://github.com/OpenEnergyPlatform/open-MaStR/actions/runs/14723137414)
- [Package on test.pypi.org](https://test.pypi.org/project/open-mastr/0.15.1/)

Finally closes #612 