### PR TITLE
Add "Einheittyp" to system_catalog #651

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ## [v0.XX.X] unreleased - 202X-XX-XX
 ### Added
 ### Changed
+- Updates the system_catalog dict with missing Einheittyp values
+  [#653](https://github.com/OpenEnergyPlatform/open-MaStR/pull/653)
 - Fix package publication workflow
   [#636](https://github.com/OpenEnergyPlatform/open-MaStR/pull/636)
 ### Removed

--- a/open_mastr/xml_download/colums_to_replace.py
+++ b/open_mastr/xml_download/colums_to_replace.py
@@ -23,6 +23,20 @@ system_catalog = {
         3: "Gaserzeugungslokation",
         4: "Gasverbrauchslokation",
     },
+    "Einheittyp": {
+        1: "Solareinheit",
+        2: "Windeinheit",
+        3: "Biomasse",
+        4: "Wasser",
+        5: "Geothermie",
+        6: "Verbrennung",
+        7: "Kernenergie",
+        8: "Stromspeichereinheit",
+        9: "Stromverbrauchseinheit",
+        10: "Gasverbrauchseinheit",
+        11: "Gaserzeugungseinheit",
+        12: "Gasspeichereinheit",
+    },
 }
 
 # columns to replace lists all columns where the entries have


### PR DESCRIPTION
## Summary of the discussion

Closes #651

## Type of change (CHANGELOG.md)

### Updated
- Updates the `system_catalog` dict with missing `Einheittyp` values

## Workflow checklist

### Automation
Closes #651

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CHANGELOG.md)
- [x] 📙 Update the documentation (not necessary in my opinion)

### Reviewer
- [x] 🐙 Follow the [Reviewer Guidelines](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [x] 🐙 Provided feedback and show sufficient appreciation for the work done
