### PR TITLE
do not set default root log level to debug

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -83,6 +83,12 @@ The project home directory is structured as follows (files and folders below `da
 For the download via the API, logs are stored in a single file in `/$HOME/<user>/.open-MaStR/logs/open_mastr.log`.
 New logging messages are appended. It is recommended to delete the log file from time to time because of its required disk space.
 
+You can add the following to enable debug logging on all loggers:
+
+```yml
+root:
+    level: "DEBUG"
+```
 
 ### Data
 

--- a/open_mastr/utils/config/logging.yml
+++ b/open_mastr/utils/config/logging.yml
@@ -17,9 +17,6 @@ handlers:
     formatter: "standard"
     mode: "a"
 
-root:
-    level: "DEBUG"
-
 loggers:
   open-MaStR:
     handlers: ["console", "file"]


### PR DESCRIPTION
## Summary of the discussion

Fixes setting of debug logging output

## Type of change (CHANGELOG.md)


## Workflow checklist

### Automation
Closes #664 

### PR-Assignee
- [ ] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CHANGELOG.md)
- [ ] 📙 Update the documentation

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
