### PR TITLE
Improvements in handling bulk downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
   [#636](https://github.com/OpenEnergyPlatform/open-MaStR/pull/636)
 - Change print statement about data cleansing
   [#650](https://github.com/OpenEnergyPlatform/open-MaStR/pull/650)
-- Several improvements in XML download: Support retaining old bulk XML files;
-  Prevent XML file deletion on full download; Add technology checks to full
+- Several improvements in bulk download: Support retaining old zip bulk files;
+  Prevent zip file deletion on full download; Add technology checks to full
   bulk download
   [#667](https://github.com/OpenEnergyPlatform/open-MaStR/pull/667)
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
   [#636](https://github.com/OpenEnergyPlatform/open-MaStR/pull/636)
 - Change print statement about data cleansing
   [#650](https://github.com/OpenEnergyPlatform/open-MaStR/pull/650)
+- Several improvements in XML download: Support retaining old bulk XML files;
+  Prevent XML file deletion on full download; Add technology checks to full
+  bulk download
+  [#667](https://github.com/OpenEnergyPlatform/open-MaStR/pull/667)
 ### Removed
 
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -150,6 +150,9 @@ If needed, the tables in the database can be obtained as csv files. Those files 
     * No single tables or entries can be downloaded
     * Download takes long time (you can use the partial download though, see [Getting Started](getting_started.md#bulk-download))
 
+**Note**: By default, existing zip files in `$HOME/.open-MaStR/data/xml_download` are deleted when a new file is
+downloaded. You can change this behavior by setting `keep_old_downloads`=True in
+[`Mastr.download()`][open_mastr.Mastr.download].
 
 ## SOAP API download
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -148,7 +148,7 @@ If needed, the tables in the database can be obtained as csv files. Those files 
 
 === "Disadvantages"
     * No single tables or entries can be downloaded
-    * Download takes long time
+    * Download takes long time (you can use the partial download though, see [Getting Started](getting_started.md#bulk-download))
 
 
 ## SOAP API download

--- a/open_mastr/mastr.py
+++ b/open_mastr/mastr.py
@@ -238,11 +238,11 @@ class Mastr:
             )
 
             delete_zip_file_if_corrupted(zipped_xml_file_path)
-            delete_xml_files_not_from_given_date(
-                zipped_xml_file_path,
-                xml_folder_path,
-                keep_old_downloads,
-            )
+            if not keep_old_downloads:
+                delete_xml_files_not_from_given_date(
+                    zipped_xml_file_path,
+                    xml_folder_path,
+                )
 
             download_xml_Mastr(zipped_xml_file_path, date, data, xml_folder_path)
 

--- a/open_mastr/mastr.py
+++ b/open_mastr/mastr.py
@@ -107,6 +107,7 @@ class Mastr:
         data=None,
         date=None,
         bulk_cleansing=True,
+        keep_old_downloads: bool = False,
         api_processes=None,
         api_limit=50,
         api_chunksize=1000,
@@ -168,6 +169,8 @@ class Mastr:
             In its original format, many entries in the MaStR are encoded with IDs. Columns like
             `state` or `fueltype` do not contain entries such as "Hessen" or "Braunkohle", but instead
             only contain IDs. Cleansing replaces these IDs with their corresponding original entries.
+        keep_old_downloads: bool
+            If set to True, prior downloaded MaStR zip files will be kept.
         api_processes : int or None or "max", optional
             Number of parallel processes used to download additional data.
             Defaults to `None`. If set to "max", the maximum number of possible processes
@@ -235,7 +238,11 @@ class Mastr:
             )
 
             delete_zip_file_if_corrupted(zipped_xml_file_path)
-            delete_xml_files_not_from_given_date(zipped_xml_file_path, xml_folder_path)
+            delete_xml_files_not_from_given_date(
+                zipped_xml_file_path,
+                xml_folder_path,
+                keep_old_downloads,
+            )
 
             download_xml_Mastr(zipped_xml_file_path, date, data, xml_folder_path)
 

--- a/open_mastr/xml_download/utils_download_bulk.py
+++ b/open_mastr/xml_download/utils_download_bulk.py
@@ -123,7 +123,11 @@ def download_xml_Mastr(
     Parameters
     -----------
     save_path: str
-        The path where the downloaded MaStR zipped folder will be saved.
+        Full file path where the downloaded MaStR zip file will be saved.
+    bulk_date_string: str
+        Date for which the file should be downloaded.
+    xml_folder_path: str
+        Path where the downloaded MaStR zip file will be saved.
     """
 
     print_message = "Starting the Download from marktstammdatenregister.de."
@@ -197,16 +201,30 @@ def check_download_completeness(
     return list(missing_data_set), is_katalogwerte_existing
 
 
-def delete_xml_files_not_from_given_date(save_path: str, xml_folder_path: str):
+def delete_xml_files_not_from_given_date(
+    save_path: str,
+    xml_folder_path: str,
+    keep_old_downloads: bool = False,
+) -> None:
     """
     Delete xml files that are not corresponding to the given date.
     Assumes that the xml folder only contains one zipfile.
+
+    Parameters
+    ----------
+    save_path: str
+        Full file path where the downloaded MaStR zip file will be saved.
+    xml_folder_path: str
+        Path where the downloaded MaStR zip file will be saved.
+    keep_old_downloads: bool
+        If set to True, prior downloaded MaStR zip files will be kept.
     """
     if os.path.exists(save_path):
         return
     else:
-        shutil.rmtree(xml_folder_path)
-        os.makedirs(xml_folder_path)
+        if not keep_old_downloads:
+            shutil.rmtree(xml_folder_path)
+            os.makedirs(xml_folder_path)
 
 
 def partial_download_with_unzip_http(save_path: str, url: str, bulk_data_list: list):

--- a/open_mastr/xml_download/utils_download_bulk.py
+++ b/open_mastr/xml_download/utils_download_bulk.py
@@ -206,7 +206,6 @@ def check_download_completeness(
 def delete_xml_files_not_from_given_date(
     save_path: str,
     xml_folder_path: str,
-    keep_old_downloads: bool = False,
 ) -> None:
     """
     Delete xml files that are not corresponding to the given date.
@@ -218,15 +217,12 @@ def delete_xml_files_not_from_given_date(
         Full file path where the downloaded MaStR zip file will be saved.
     xml_folder_path: str
         Path where the downloaded MaStR zip file will be saved.
-    keep_old_downloads: bool
-        If set to True, prior downloaded MaStR zip files will be kept.
     """
     if os.path.exists(save_path):
         return
     else:
-        if not keep_old_downloads:
-            shutil.rmtree(xml_folder_path)
-            os.makedirs(xml_folder_path)
+        shutil.rmtree(xml_folder_path)
+        os.makedirs(xml_folder_path)
 
 
 def partial_download_with_unzip_http(save_path: str, url: str, bulk_data_list: list):

--- a/open_mastr/xml_download/utils_download_bulk.py
+++ b/open_mastr/xml_download/utils_download_bulk.py
@@ -168,13 +168,13 @@ def download_xml_Mastr(
         return
 
     if bulk_data_list == BULK_DATA:
-        full_download_without_unzip_http(save_path, r)
+        full_download_without_unzip_http(save_path, r, bulk_data_list)
     else:
         try:
             partial_download_with_unzip_http(save_path, url, bulk_data_list)
         except Exception as e:
             log.warning(f"Partial download failed, fallback to full download: {e}")
-            full_download_without_unzip_http(save_path, r)
+            full_download_without_unzip_http(save_path, r, bulk_data_list)
 
     time_b = time.perf_counter()
     print(f"Download is finished. It took {int(np.around(time_b - time_a))} seconds.")
@@ -271,7 +271,38 @@ def partial_download_with_unzip_http(save_path: str, url: str, bulk_data_list: l
         remote_zip_file.extractzip("Katalogwerte.xml", path=Path(save_path))
 
 
-def full_download_without_unzip_http(save_path: str, r: requests.models.Response):
+def full_download_without_unzip_http(
+    save_path: str,
+    r: requests.models.Response,
+    bulk_data_list: list,
+) -> None:
+    """
+
+    Parameters
+    ----------
+    save_path: str
+        Full file path where the downloaded MaStR zip file will be saved.
+    r: requests.models.Response
+        Response from making a request to MaStR.
+    bulk_data_list: list
+        List of tables/technologis to be downloaded.
+
+    Returns
+    -------
+    None
+    """
+    if os.path.exists(save_path):
+        bulk_data_list, is_katalogwerte_existing = check_download_completeness(
+            save_path, bulk_data_list
+        )
+        if bool(bulk_data_list):
+            print(
+                f"MaStR file already present but missing the following data: {bulk_data_list}"
+            )
+        else:
+            print(f"MaStR file already present: {save_path}")
+            return None
+
     warning_message = (
         "Warning: The servers from MaStR restrict the download speed."
         " You may want to download it another time."

--- a/open_mastr/xml_download/utils_download_bulk.py
+++ b/open_mastr/xml_download/utils_download_bulk.py
@@ -126,6 +126,8 @@ def download_xml_Mastr(
         Full file path where the downloaded MaStR zip file will be saved.
     bulk_date_string: str
         Date for which the file should be downloaded.
+    bulk_data_list: list
+        List of tables/technologis to be downloaded.
     xml_folder_path: str
         Path where the downloaded MaStR zip file will be saved.
     """

--- a/open_mastr/xml_download/utils_download_bulk.py
+++ b/open_mastr/xml_download/utils_download_bulk.py
@@ -230,15 +230,32 @@ def delete_xml_files_not_from_given_date(
 
 
 def partial_download_with_unzip_http(save_path: str, url: str, bulk_data_list: list):
+    """
+
+    Parameters
+    ----------
+    save_path: str
+        Full file path where the downloaded MaStR zip file will be saved.
+    url: str
+        URL path to bulk file.
+    bulk_data_list: list
+        List of tables/technologis to be downloaded.
+
+    Returns
+    -------
+    None
+    """
     is_katalogwerte_existing = False
     if os.path.exists(save_path):
         bulk_data_list, is_katalogwerte_existing = check_download_completeness(
             save_path, bulk_data_list
         )
         if bool(bulk_data_list):
-            print(f"MaStR is missing the following data: {bulk_data_list}")
+            print(
+                f"MaStR file already present but missing the following data: {bulk_data_list}"
+            )
         else:
-            print("MaStR already downloaded.")
+            print(f"MaStR file already present: {save_path}")
             return None
 
     remote_zip_file = unzip_http.RemoteZipFile(url)

--- a/tests/test_mastr.py
+++ b/tests/test_mastr.py
@@ -14,6 +14,16 @@ if os.path.isdir(_xml_folder_path):
             _xml_file_exists = True
 
 
+@pytest.fixture(scope="module")
+def zipped_xml_file_path():
+    zipped_xml_file_path = None
+    for entry in os.scandir(path=_xml_folder_path):
+        if "Gesamtdatenexport" in entry.name:
+            zipped_xml_file_path = os.path.join(_xml_folder_path, entry.name)
+
+    return zipped_xml_file_path
+
+
 @pytest.fixture
 def db_path():
     return os.path.join(

--- a/tests/test_mastr.py
+++ b/tests/test_mastr.py
@@ -1,10 +1,14 @@
+import shutil
+
 from open_mastr.mastr import Mastr
 import os
+import re
 import sqlalchemy
 import pytest
 from os.path import expanduser
 import pandas as pd
 from open_mastr.utils.constants import TRANSLATIONS
+from datetime import date, timedelta
 
 _xml_file_exists = False
 _xml_folder_path = os.path.join(expanduser("~"), ".open-MaStR", "data", "xml_download")
@@ -83,6 +87,7 @@ def test_Mastr_translate(db_translated, db_path):
         assert pd.read_sql(sql=table, con=db_empty.engine).shape[0] == 0
 
 
+@pytest.mark.dependency(name="bulk_downloaded")
 def test_mastr_download(db):
     db.download(data="wind")
     df_wind = pd.read_sql("wind_extended", con=db.engine)
@@ -92,3 +97,15 @@ def test_mastr_download(db):
     df_biomass = pd.read_sql("biomass_extended", con=db.engine)
     assert len(df_wind) > 10000
     assert len(df_biomass) > 10000
+
+
+@pytest.mark.dependency(depends=["bulk_downloaded"])
+def test_mastr_download_keep_old_files(db, zipped_xml_file_path):
+    file_today = zipped_xml_file_path
+    yesterday = (date.today() - timedelta(days=1)).strftime("%Y%m%d")
+    file_old = re.sub(r"\d{8}", yesterday, os.path.basename(file_today))
+    file_old = os.path.join(os.path.dirname(zipped_xml_file_path), file_old)
+    shutil.copy(file_today, file_old)
+    db.download(data="gsgk", keep_old_files=True)
+
+    assert os.path.exists(file_old)


### PR DESCRIPTION
## Summary of the discussion

- Introduce parameter to allow keeping old XML files #564 
- Prevent deletion of up-to-date zip file on full bulk download #668
- Add technology checks to full bulk download -> do not download if data is present; fixed behavior for full and partial download:
  - zip file **does** contain all technologies -> use existing zip file
  - zip file **does not** contain all requested technologies -> download full / partial

## Workflow checklist

### Automation
Closes #564
Fixes #668

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CHANGELOG.md)
- [x] 📙 Update the documentation

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
