### PR TITLE
Limit number of parallel CI jobs

### DIFF
--- a/.github/workflows/ci-develop.yml
+++ b/.github/workflows/ci-develop.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     if: ${{ !github.event.pull_request.draft }}
     strategy:
+      max-parallel: 1
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         python-version: ['3.10', '3.11', '3.12']

--- a/.github/workflows/ci-production.yml
+++ b/.github/workflows/ci-production.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     if: ${{ !github.event.pull_request.draft }}
     strategy:
+      max-parallel: 1
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         python-version: ['3.10', '3.11', '3.12']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
   [#636](https://github.com/OpenEnergyPlatform/open-MaStR/pull/636)
 - Change print statement about data cleansing
   [#650](https://github.com/OpenEnergyPlatform/open-MaStR/pull/650)
+- Limit number of parallel CI jobs
+  [#669](https://github.com/OpenEnergyPlatform/open-MaStR/pull/669)
 ### Removed
 
 


### PR DESCRIPTION
Limiting the number of parallel CI jobs prevents being blocked by the MaStR server due to parallel HTTP requests by GH actions. To make sure we won't run into problems (and as duration for the tests is not too important) I've set the count to 1. 

Following the testing progress I can confirm that only one is executed at a time.
The total duration is ~23min

## Workflow checklist

### Automation
Closes #660

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CHANGELOG.md)
- [ ] 📙 Update the documentation

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
