### PR TITLE
Fix line underline for publishing to PyPI

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -38,5 +38,4 @@ jobs:
         --wheel
         --outdir dist/
     - name: Publish distribution 📦 to PyPI
-      if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ For each version important additions, changes and removals are listed here.
 The format is inspired from [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v0.XX.X] unreleased - 202X-XX-XX
+### Added
+
+### Changed
+
+### Removed
+
 ## [v0.16.1] Hotfix - 2025-12-17
 
 ### Changed

--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ In particular, ``open-mastr`` facilitates access to the daily provided MaStR dum
 No. ``open-mastr`` is a wrapper around the MaStR data and does not edit or change the data. It is intended to be used as a tool for working with the MaStR data.
 
 Benefits provided by ``open-mastr``
-==================================
+===================================
 
 .. list-table::
    :widths: 30, 70


### PR DESCRIPTION
Fixes the crashing PyPI publishing, see [workflow run](https://github.com/OpenEnergyPlatform/open-MaStR/actions/runs/20342695256/job/58446236637).

Problem was introduced in #647. This underscores the need for the new linting #671 which would have prevented this problem.