### PR TITLE
Fix heading underline for publishing to PyPI 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ In particular, ``open-mastr`` facilitates access to the daily provided MaStR dum
 No. ``open-mastr`` is a wrapper around the MaStR data and does not edit or change the data. It is intended to be used as a tool for working with the MaStR data.
 
 Benefits provided by ``open-mastr``
-==================================
+===================================
 
 .. list-table::
    :widths: 30, 70


### PR DESCRIPTION
Fixes the crashing PyPI publishing, see [workflow run](https://github.com/OpenEnergyPlatform/open-MaStR/actions/runs/20342695256/job/58446236637).

Problem was introduced in #647. This underscores the need for the new linting #671 which would have prevented this problem.