### PR TITLE
Add two missing translations for wind power plants #714

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ### Added
 - Add trusted publishing for test releases
   [#713](https://github.com/OpenEnergyPlatform/open-MaStR/pull/713)
+- Update list for english column translation
+  [#715](https://github.com/OpenEnergyPlatform/open-MaStR/pull/715)
 ### Changed
 
 ### Removed

--- a/open_mastr/utils/constants.py
+++ b/open_mastr/utils/constants.py
@@ -514,5 +514,5 @@ TRANSLATIONS = {
     "WebportalDesNetzbetreibers": "webPortalGridOperator",
     "RegisternummerPraefix": "registerNumberPrefix",
     "TechnologieFlugwind": "technologyAirborne",
-    "WindAnLandOderAufSee": "windOnshoreOrAtSea",
+    "WindAnLandOderAufSee": "windOnshoreOrOffshore",
 }

--- a/open_mastr/utils/constants.py
+++ b/open_mastr/utils/constants.py
@@ -513,4 +513,6 @@ TRANSLATIONS = {
     "ReserveartNachDemEnWG": "typeOfReserveFromEnWG",
     "WebportalDesNetzbetreibers": "webPortalGridOperator",
     "RegisternummerPraefix": "registerNumberPrefix",
+    "TechnologieFlugwind": "technologyAirborne",
+    "WindAnLandOderAufSee": "windOnshoreOrAtSea",
 }


### PR DESCRIPTION
## Summary of the discussion

Add two missing translations for wind power plants
 
## Type of change (CHANGELOG.md)

### Added
- Translation for "TechnologieFlugwind" and "WindAnLandOderAufSee"

## Workflow checklist

### Automation
Closes #714

### PR-Assignee
- [ ] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CHANGELOG.md)
- [ ] 📙 Update the documentation

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
