### PR TITLE
Zero fill specific date strings #719

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ### Changed
 - Replace Marktrollen with MarktakteureUndRollen
   [#722](https://github.com/OpenEnergyPlatform/open-MaStR/pull/722)
+- Zero fill specific date strings [#728](https://github.com/OpenEnergyPlatform/open-MaStR/pull/728)
 
 ### Removed
 

--- a/open_mastr/xml_download/utils_write_to_database.py
+++ b/open_mastr/xml_download/utils_write_to_database.py
@@ -281,7 +281,10 @@ def cast_date_columns_to_string(xml_table_name: str, df: pd.DataFrame) -> pd.Dat
 
         if type(column[1].type) is Date:
             df[column_name] = (
-                df[column_name].dt.strftime("%Y-%m-%d").replace("NaT", None)
+                df[column_name]
+                .dt.strftime("%Y-%m-%d")
+                .replace("NaT", None)
+                .str.zfill(10)
             )
         elif type(column[1].type) is DateTime:
             df[column_name] = (

--- a/open_mastr/xml_download/utils_write_to_database.py
+++ b/open_mastr/xml_download/utils_write_to_database.py
@@ -280,12 +280,11 @@ def cast_date_columns_to_string(xml_table_name: str, df: pd.DataFrame) -> pd.Dat
         df[column_name] = pd.to_datetime(df[column_name], errors="coerce")
 
         if type(column[1].type) is Date:
-            df[column_name] = (
-                df[column_name]
-                .dt.strftime("%Y-%m-%d")
-                .replace("NaT", None)
-                .str.zfill(10)
-            )
+            mask = df[column_name].notna()
+            df[column_name] = df[column_name].dt.strftime("%Y-%m-%d")
+            df.loc[mask, column_name] = df.loc[mask, column_name].str.zfill(10)
+            df[column_name] = df[column_name].replace("NaT", None)
+
         elif type(column[1].type) is DateTime:
             df[column_name] = (
                 df[column_name].dt.strftime("%Y-%m-%d %H:%M:%S.%f").replace("NaT", None)


### PR DESCRIPTION
## Summary of the discussion

When date-typos occur in years (0219 instead of 2019) and we do not pad these values when converting to string, the pandas `pd.read_sql` call cannot handle three-digit-years, it is simply not a correct isoformat, see #719.

## Type of change (CHANGELOG.md)

### Updated
- Added `.str.zfill(10)` in `cast_date_columns_to_string`

## Workflow checklist

- [x] I have not yet checked other possible occurences in the code where we handle datetimes
- [x] I have to workaround the fact that `None.str.zfill(10)` does not work because `'NoneType' object has no attribute 'str'`
  - Fixed [here](https://github.com/OpenEnergyPlatform/open-MaStR/pull/728/changes/d14829447bbecb87d63d5a347386c9f717e52cd9)

### Automation
Closes #719

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CHANGELOG.md)
- [x] 📙 Update the documentation

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
