### PR TITLE
HOTFIX-733: Fix broken Mastr.to_csv by removing stray kwargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ### Added
 
 ### Changed
+- Fix broken `Mastr.to_csv` function by removing stray `**kwargs`
+  [#736](https://github.com/OpenEnergyPlatform/open-MaStR/pull/736)
 
 ### Removed
 

--- a/open_mastr/mastr.py
+++ b/open_mastr/mastr.py
@@ -284,7 +284,7 @@ class Mastr:
 
         # Validate and parse tables parameter
         validate_parameter_data(method="csv_export", data=tables)
-        data = transform_data_parameter(tables, **kwargs)
+        data = transform_data_parameter(tables)
 
         # Determine tables to export
         technologies_to_export = []


### PR DESCRIPTION
## Summary of the discussion

@Postiii pointed out in #733 that the `to_csv` method was broken with the `0.17.0` release. I'm fixing this here.

## Type of change (CHANGELOG.md)

### Updated
- Fix broken `Mastr.to_csv` function by removing stray `**kwargs`

## Workflow checklist

- [x] Checked that `Mastr.to_csv` works with this fix.

### Automation
Closes #733

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CHANGELOG.md)
- [ ] 📙 Update the documentation
  - Not applicable

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
