### PR TITLE
Release v0.17.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.17.0
+current_version = 0.17.1
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>(a|na))+(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}{release}{build}

--- a/.github/workflows/ci-production.yml
+++ b/.github/workflows/ci-production.yml
@@ -33,7 +33,7 @@ jobs:
     - name: create package
       run: python -m build --sdist
     - name: import open-mastr
-      run: python -m pip install ./dist/open_mastr-0.17.0.tar.gz
+      run: python -m pip install ./dist/open_mastr-0.17.1.tar.gz
     - name: Create credentials file
       env:
         MASTR_TOKEN: ${{ secrets.MASTR_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 ### Added
 
 ### Changed
+- Fix broken `Mastr.to_csv` function by removing stray `**kwargs`
+  [#736](https://github.com/OpenEnergyPlatform/open-MaStR/pull/736)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ For each version important additions, changes and removals are listed here.
 The format is inspired from [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v0.xx.x] Unreleased - 202x-xx-xx
+### Added
+
+### Changed
+
+### Removed
+
+
 ## [v0.17.0] Full download via SOAP API deprecation and interactive download functionality - 2026-04-02
 ### Added
 - Add interactive download functionality for MaStR date selection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,10 @@ For each version important additions, changes and removals are listed here.
 The format is inspired from [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [v0.xx.x] Unreleased - 202x-xx-xx
-### Added
-
+## [v0.17.1] Hotfix - 2026-04-13
 ### Changed
 - Fix broken `Mastr.to_csv` function by removing stray `**kwargs`
   [#736](https://github.com/OpenEnergyPlatform/open-MaStR/pull/736)
-
-### Removed
 
 
 ## [v0.17.0] Full download via SOAP API deprecation and interactive download functionality - 2026-04-02

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -36,12 +36,16 @@ authors:
     affiliation: "Technical University of Munich"
   - family-names: 'Krämer'
     given-names: "Kevin"
-    alias: "pt-kkraemer"
-    affiliation: "ProjectTogether gGmbH"  
+    alias: "@pt-kkraemer"
+    affiliation: "ProjectTogether gGmbH"
+  - family-names: 'Will'
+    given-names: "Simon"
+    alias: "@Simon-Will"
+    affiliation: ""
 title: "open-MaStR"
 type: software
 license: AGPL-3.0
-version: 0.17.0
+version: 0.17.1
 doi: 
-date-released: 2026-04-02
+date-released: 2026-04-13
 url: "https://github.com/OpenEnergyPlatform/open-MaStR/"

--- a/open_mastr/mastr.py
+++ b/open_mastr/mastr.py
@@ -284,7 +284,7 @@ class Mastr:
 
         # Validate and parse tables parameter
         validate_parameter_data(method="csv_export", data=tables)
-        data = transform_data_parameter(tables, **kwargs)
+        data = transform_data_parameter(tables)
 
         # Determine tables to export
         technologies_to_export = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open_mastr"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
   "pandas>=2.2.2",
   "numpy",
@@ -79,4 +79,4 @@ open_mastr = [
 include = ["open_mastr", "open_mastr.soap_api", "open_mastr.soap_api.metadata", "open_mastr.utils", "open_mastr.utils.config", "open_mastr.xml_download"] # package names should match these glob patterns (["*"] by default)
 
 # from setup.py - not yet included in here
-# download_url="https://github.com/OpenEnergyPlatform/open-MaStR/archive""/refs/tags/v0.17.0.tar.gz",
+# download_url="https://github.com/OpenEnergyPlatform/open-MaStR/archive""/refs/tags/v0.17.1.tar.gz",


### PR DESCRIPTION
## [v0.17.1] Hotfix - 2026-04-13
### Changed
- Fix broken `Mastr.to_csv` function by removing stray `**kwargs`
  [#736](https://github.com/OpenEnergyPlatform/open-MaStR/pull/736)

Closes #738