### PR TITLE
Make project home configurable #689

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
     [#718](https://github.com/OpenEnergyPlatform/open-MaStR/pull/718)
 
   ### Changed
+  - Refactor data path configuration: remove `get_data_version_dir()`, add `MASTR_PROJECT_HOME_DIR` env var support to `get_project_home_dir()`
+    [#748](https://github.com/OpenEnergyPlatform/open-MaStR/pull/748)
   - Switch to dynamic table generation based on parsing of XSD files from the MaStR documentation; fall back to bundled XSD files if the downloaded documentation is invalid
     [#718](https://github.com/OpenEnergyPlatform/open-MaStR/pull/718)
   - Change default table and column names to align more closely with the original MaStR export file names

--- a/open_mastr/mastr.py
+++ b/open_mastr/mastr.py
@@ -32,7 +32,7 @@ from open_mastr.utils.helpers import (
     create_database_engine,
 )
 from open_mastr.utils.config import (
-    get_data_version_dir,
+    get_data_config,
     get_output_dir,
     setup_logger,
 )
@@ -435,7 +435,7 @@ class Mastr:
             Number of rows to retrieve from the database before dumping them to the CSV file.
             Defaults to 500000.
         """
-        data_path = get_data_version_dir()
+        data_path = os.path.join(self.output_dir, "data", get_data_config())
         os.makedirs(data_path, exist_ok=True)
 
         inspector = inspect(self.engine)

--- a/open_mastr/utils/config.py
+++ b/open_mastr/utils/config.py
@@ -36,7 +36,7 @@ log = logging.getLogger(__name__)
 
 
 def get_project_home_dir():
-    """Get root dir of project data
+    """Get root dir of project data, where credentials and config files are located.
 
     On linux this path equals `$HOME/.open-MaStR/`, respectively `~/.open-MaStR/`
     which is also called `PROJECTHOME`.
@@ -46,6 +46,8 @@ def get_project_home_dir():
     path-like object
         Absolute path to root dir of open-MaStR project home
     """
+    if "MASTR_PROJECT_HOME_DIR" in os.environ:
+        return os.environ.get("MASTR_PROJECT_HOME_DIR")
 
     return os.path.join(os.path.expanduser("~"), ".open-MaStR")
 
@@ -63,25 +65,6 @@ def get_output_dir():
         return os.environ.get("OUTPUT_PATH")
 
     return get_project_home_dir()
-
-
-def get_data_version_dir():
-    """
-    Subdirectory of data/ in PROJECTHOME
-
-    See :ref:`docs <Project directory>` for configuration of data version.
-
-    Returns
-    -------
-    path-like object
-        Absolute path to `PROJECTHOME/data/<data-version>/`
-    """
-    data_version = get_data_config()
-
-    if "OUTPUT_PATH" in os.environ:
-        return os.path.join(os.environ.get("OUTPUT_PATH"), "data", data_version)
-
-    return os.path.join(get_project_home_dir(), "data", data_version)
 
 
 def get_filenames():
@@ -113,7 +96,7 @@ def get_data_config():
 
     today = date.today()
 
-    data_config = f'dataversion-{today.strftime("%Y-%m-%d")}'
+    data_config = f"dataversion-{today.strftime('%Y-%m-%d')}"
 
     return data_config
 
@@ -196,7 +179,6 @@ def _filenames_generator():
     for section, section_filenames in filenames_template.items():
         filenames[section] = {}
         for tech in TECHNOLOGIES:
-
             # Files for all technologies
             files = ["joined", "basic", "extended", "extended_fail"]
 


### PR DESCRIPTION
* Remove get_data_version_dir() - This function is redundant as its logic can be inlined where it's used (e.g., in mastr.py:438 as os.path.join(self.output_dir, "data", get_data_config()))
* Add MASTR_PROJECT_HOME_DIR environment variable support to get_project_home_dir() - Currently only OUTPUT_PATH is respected, but users need to be able to override the base project home directory itself (where credentials and config are stored), not just the output path - this is relevant for setting up a project home for testing


### PR-Assignee
- [ ] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CHANGELOG.md)
- [ ] 📙 Update the documentation

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
