### PR TITLE
robust parsing of xsd metdatadata files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 
 
   ### Changed
-  - Add support for reading XSD files from both zipped and unzipped documentation sources
+  - Add support for reading XSD files from both zipped / unzipped documentation sources
     [#761](https://github.com/OpenEnergyPlatform/open-MaStR/pull/761)
   - Refactor data path configuration: remove `get_data_version_dir()`, add `MASTR_PROJECT_HOME_DIR` env var support to `get_project_home_dir()`
     [#748](https://github.com/OpenEnergyPlatform/open-MaStR/pull/748)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 
 
   ### Changed
+  - Add support for reading XSD files from both zipped and unzipped documentation sources
+    [#761](https://github.com/OpenEnergyPlatform/open-MaStR/pull/761)
   - Refactor data path configuration: remove `get_data_version_dir()`, add `MASTR_PROJECT_HOME_DIR` env var support to `get_project_home_dir()`
     [#748](https://github.com/OpenEnergyPlatform/open-MaStR/pull/748)
   - Switch to dynamic table generation based on parsing of XSD files from the MaStR documentation; fall back to bundled XSD files if the downloaded documentation is invalid

--- a/open_mastr/utils/xsd_tables.py
+++ b/open_mastr/utils/xsd_tables.py
@@ -3,7 +3,7 @@ import os
 from enum import auto, Enum
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Union, Iterator
+from typing import Optional, Union, Iterator, IO
 from zipfile import ZipFile
 import xmlschema
 from xmlschema.validators.simple_types import XsdAtomicBuiltin, XsdAtomicRestriction

--- a/open_mastr/utils/xsd_tables.py
+++ b/open_mastr/utils/xsd_tables.py
@@ -162,7 +162,9 @@ class InvalidXmlSchemaError(Exception):
 
 
 def _iterate_xsd_files(source: Union[Path, str]) -> Iterator[tuple[str, IO[bytes]]]:
-    """Iterate over .xsd files in either a zip containing xsd or xsd.zip.
+    """Iterate over .xsd files in a ZIP file or directory.
+    
+    Source can either be a directory directly containing `*.xsd` files, or a ZIP file that contains either an `xsd` directory or another ZIP file called `xsd.zip`.
 
     Yields tuples of (name, file_object) where file_object is a context manager.
     """

--- a/open_mastr/utils/xsd_tables.py
+++ b/open_mastr/utils/xsd_tables.py
@@ -161,7 +161,7 @@ class InvalidXmlSchemaError(Exception):
     pass
 
 
-def _iterate_xsd_files(source: Union[Path, str]):
+def _iterate_xsd_files(source: Union[Path, str]) -> Iterator[tuple[str, IO[bytes]]]:
     """Iterate over .xsd files in either a zip containing xsd or xsd.zip.
 
     Yields tuples of (name, file_object) where file_object is a context manager.

--- a/open_mastr/utils/xsd_tables.py
+++ b/open_mastr/utils/xsd_tables.py
@@ -3,7 +3,7 @@ import os
 from enum import auto, Enum
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional, Union, Iterator
 from zipfile import ZipFile
 import xmlschema
 from xmlschema.validators.simple_types import XsdAtomicBuiltin, XsdAtomicRestriction
@@ -163,7 +163,7 @@ class InvalidXmlSchemaError(Exception):
 
 def _iterate_xsd_files(source: Union[Path, str]) -> Iterator[tuple[str, IO[bytes]]]:
     """Iterate over .xsd files in a ZIP file or directory.
-    
+
     Source can either be a directory directly containing `*.xsd` files, or a ZIP file that contains either an `xsd` directory or another ZIP file called `xsd.zip`.
 
     Yields tuples of (name, file_object) where file_object is a context manager.

--- a/open_mastr/utils/xsd_tables.py
+++ b/open_mastr/utils/xsd_tables.py
@@ -24,20 +24,31 @@ def normalize_mastr_name(original_mastr_name: str) -> str:
     Also, in case the column names in the XSD contain äöüß, we replace them.
     This is probably a BNetzA oversight, but has happened at least once.
     """
-    return original_mastr_name.replace("MaStR", "Mastr").replace("ä", "ae").replace("ö", "oe").replace("ü", "ue").replace("ß", "ss").strip()
+    return (
+        original_mastr_name.replace("MaStR", "Mastr")
+        .replace("ä", "ae")
+        .replace("ö", "oe")
+        .replace("ü", "ue")
+        .replace("ß", "ss")
+        .strip()
+    )
 
 
 def translate_mastr_column_name(normalized_mastr_column_name: str) -> Optional[str]:
     translated = COLUMN_TRANSLATIONS.get(normalized_mastr_column_name)
     if not translated:
-        log.warning(f"No translation available for column {normalized_mastr_column_name!r}")
+        log.warning(
+            f"No translation available for column {normalized_mastr_column_name!r}"
+        )
     return translated
 
 
 def translate_mastr_table_name(normalized_mastr_table_name: str) -> Optional[str]:
     translated = TABLE_TRANSLATIONS.get(normalized_mastr_table_name)
     if not translated:
-        log.warning(f"No translation available for table {normalized_mastr_table_name!r}")
+        log.warning(
+            f"No translation available for table {normalized_mastr_table_name!r}"
+        )
     return translated
 
 
@@ -51,7 +62,9 @@ class MastrColumnType(Enum):
     CATALOG_VALUE = auto()
 
     @classmethod
-    def from_xsd_type(cls, xsd_type: Union[XsdAtomicBuiltin, XsdAtomicRestriction]) -> "MastrColumnDescription":
+    def from_xsd_type(
+        cls, xsd_type: Union[XsdAtomicBuiltin, XsdAtomicRestriction]
+    ) -> "MastrColumnDescription":
         xsd_type_to_mastr_column_type = {
             f"{_XML_SCHEMA_PREFIX}string": cls.STRING,
             f"{_XML_SCHEMA_PREFIX}decimal": cls.INTEGER,
@@ -70,13 +83,17 @@ class MastrColumnType(Enum):
             # Ertuechtigungen.xsd has some normal types defined as restrictions for some reason.
             # We cope with that by extracting the primitive type it's restricted to.
             inner_xsd_type = xsd_type.primitive_type
-            if mastr_column_type := xsd_type_to_mastr_column_type.get(inner_xsd_type.name):
+            if mastr_column_type := xsd_type_to_mastr_column_type.get(
+                inner_xsd_type.name
+            ):
                 return mastr_column_type
 
         if mastr_column_type := xsd_type_to_mastr_column_type.get(xsd_type.name):
             return mastr_column_type
 
-        raise ValueError(f"Could not determine MastrColumnType from XSD type {xsd_type!r}")
+        raise ValueError(
+            f"Could not determine MastrColumnType from XSD type {xsd_type!r}"
+        )
 
 
 @dataclass(frozen=True)
@@ -87,13 +104,15 @@ class MastrColumnDescription:
     type: MastrColumnType
 
     @classmethod
-    def from_xsd_element(cls, xsd_element: xmlschema.XsdElement) -> "MastrColumnDescription":
+    def from_xsd_element(
+        cls, xsd_element: xmlschema.XsdElement
+    ) -> "MastrColumnDescription":
         normalized_name = normalize_mastr_name(xsd_element.name)
         return cls(
             original_name=xsd_element.name,
             normalized_name=normalized_name,
             english_name=translate_mastr_column_name(normalized_name),
-            type=MastrColumnType.from_xsd_type(xsd_element.type)
+            type=MastrColumnType.from_xsd_type(xsd_element.type),
         )
 
 
@@ -155,7 +174,9 @@ def read_mastr_table_descriptions_from_xsd(
                 if entry.is_dir() or not entry.filename.endswith(".xsd"):
                     continue
 
-                normalized_name = os.path.basename(entry.filename).removesuffix(".xsd").lower()
+                normalized_name = (
+                    os.path.basename(entry.filename).removesuffix(".xsd").lower()
+                )
                 if normalized_name in include_tables:
                     with xsd_z.open(entry) as xsd_file:
                         try:
@@ -164,7 +185,9 @@ def read_mastr_table_descriptions_from_xsd(
                             raise InvalidXmlSchemaError(
                                 f"Invalid XML Schema in {os.path.basename(entry.filename)}"
                             ) from e
-                        mastr_table_description = MastrTableDescription.from_xml_schema(schema)
+                        mastr_table_description = MastrTableDescription.from_xml_schema(
+                            schema
+                        )
                         mastr_table_descriptions.add(mastr_table_description)
 
     return mastr_table_descriptions

--- a/open_mastr/utils/xsd_tables.py
+++ b/open_mastr/utils/xsd_tables.py
@@ -4,7 +4,7 @@ from enum import auto, Enum
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional, Union
-from zipfile import ZipFile, ZipInfo
+from zipfile import ZipFile
 import xmlschema
 from xmlschema.validators.simple_types import XsdAtomicBuiltin, XsdAtomicRestriction
 from xmlschema.validators.exceptions import XMLSchemaModelError
@@ -161,44 +161,64 @@ class InvalidXmlSchemaError(Exception):
     pass
 
 
+def _iterate_xsd_files(source: Union[Path, str]):
+    """Iterate over .xsd files in either a zip containing xsd or xsd.zip.
+
+    Yields tuples of (name, file_object) where file_object is a context manager.
+    """
+    source_path = Path(source)
+
+    if source_path.is_dir():
+        # Case: source is already an unzipped directory containing .xsd files
+        for xsd_file in source_path.glob("**/*.xsd"):
+            yield xsd_file.name, xsd_file.open("rb")
+        return
+
+    with ZipFile(source_path, "r") as docs_z:
+        xsd_folder_entries = [
+            entry
+            for entry in docs_z.namelist()
+            if entry.endswith(".xsd")
+            and os.path.basename(os.path.dirname(entry)) == "xsd"
+        ]
+        if xsd_folder_entries:
+            # Case: plain xsd/ folder inside the docs zip
+            for entry in xsd_folder_entries:
+                yield os.path.basename(entry), docs_z.open(entry)
+            return
+
+        xsd_zip_name = next(
+            (name for name in docs_z.namelist() if os.path.basename(name) == "xsd.zip"),
+            None,
+        )
+        if xsd_zip_name is None:
+            raise RuntimeError(
+                "Did not find XSD files in the form of an 'xsd' folder or an"
+                f" 'xsd.zip' file in the documentation ZIP file {source_path!r}"
+            )
+
+        # Case: xsd.zip nested inside the docs zip
+        with ZipFile(docs_z.open(xsd_zip_name)) as xsd_z:
+            for entry in xsd_z.namelist():
+                if entry.endswith(".xsd"):
+                    yield os.path.basename(entry), xsd_z.open(entry)
+
+
 def read_mastr_table_descriptions_from_xsd(
     zipped_docs_file_path: Union[Path, str], data: list[str]
 ) -> set[MastrTableDescription]:
     include_tables = data_to_include_tables(data)
 
     mastr_table_descriptions = set()
-    with ZipFile(zipped_docs_file_path, "r") as docs_z:
-        xsd_zip_entry = _find_xsd_zip_entry(docs_z)
-        with ZipFile(docs_z.open(xsd_zip_entry)) as xsd_z:
-            for entry in xsd_z.filelist:
-                if entry.is_dir() or not entry.filename.endswith(".xsd"):
-                    continue
-
-                normalized_name = (
-                    os.path.basename(entry.filename).removesuffix(".xsd").lower()
-                )
-                if normalized_name in include_tables:
-                    with xsd_z.open(entry) as xsd_file:
-                        try:
-                            schema = xmlschema.XMLSchema(xsd_file)
-                        except XMLSchemaModelError as e:
-                            raise InvalidXmlSchemaError(
-                                f"Invalid XML Schema in {os.path.basename(entry.filename)}"
-                            ) from e
-                        mastr_table_description = MastrTableDescription.from_xml_schema(
-                            schema
-                        )
-                        mastr_table_descriptions.add(mastr_table_description)
+    for name, xsd_file in _iterate_xsd_files(zipped_docs_file_path):
+        with xsd_file:
+            normalized_name = name.removesuffix(".xsd").lower()
+            if normalized_name in include_tables:
+                try:
+                    schema = xmlschema.XMLSchema(xsd_file)
+                except XMLSchemaModelError as e:
+                    raise InvalidXmlSchemaError(f"Invalid XML Schema in {name}") from e
+                mastr_table_description = MastrTableDescription.from_xml_schema(schema)
+                mastr_table_descriptions.add(mastr_table_description)
 
     return mastr_table_descriptions
-
-
-def _find_xsd_zip_entry(docs_zip_file: ZipFile) -> ZipInfo:
-    desired_filename = "xsd.zip"
-    for entry in docs_zip_file.filelist:
-        if os.path.basename(entry.filename) == desired_filename:
-            return entry
-    raise RuntimeError(
-        f"Did not find XSD files in the form of {desired_filename!r} in the documentation"
-        f" ZIP file {docs_zip_file.filename!r}"
-    )

--- a/tests/test_xsd_tables.py
+++ b/tests/test_xsd_tables.py
@@ -1,0 +1,76 @@
+import tempfile
+import zipfile
+from pathlib import Path
+
+from open_mastr.utils.xsd_tables import (
+    read_mastr_table_descriptions_from_xsd,
+    _iterate_xsd_files,
+)
+
+MINIMAL_XSD = """<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="Root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="Instance">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="ColumnA" type="xs:string"/>
+              <xs:element name="ColumnB" type="xs:int"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>"""
+
+
+def test_iterate_xsd_files_from_directory():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        xsd_dir = Path(tmpdir) / "xsd"
+        xsd_dir.mkdir()
+        (xsd_dir / "anlageneegwind.xsd").write_text(MINIMAL_XSD)
+
+        names = [name for name, _ in _iterate_xsd_files(xsd_dir)]
+        assert names == ["anlageneegwind.xsd"]
+
+
+def test_iterate_xsd_files_from_zip_with_nested_xsd_zip():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        docs_zip_path = Path(tmpdir) / "docs.zip"
+        xsd_zip_path = Path(tmpdir) / "xsd.zip"
+
+        with zipfile.ZipFile(xsd_zip_path, "w") as xsd_z:
+            xsd_z.writestr("anlageneegwind.xsd", MINIMAL_XSD)
+
+        with zipfile.ZipFile(docs_zip_path, "w") as docs_z:
+            docs_z.write(xsd_zip_path, "xsd.zip")
+
+        names = [name for name, _ in _iterate_xsd_files(docs_zip_path)]
+        assert names == ["anlageneegwind.xsd"]
+
+
+def test_iterate_xsd_files_from_zip_with_unzipped_xsd_folder():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        docs_zip_path = Path(tmpdir) / "docs.zip"
+
+        with zipfile.ZipFile(docs_zip_path, "w") as docs_z:
+            docs_z.writestr("xsd/anlageneegwind.xsd", MINIMAL_XSD)
+
+        names = [name for name, _ in _iterate_xsd_files(docs_zip_path)]
+        assert names == ["anlageneegwind.xsd"]
+
+
+def test_read_mastr_table_descriptions_from_xsd():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        xsd_dir = Path(tmpdir) / "xsd"
+        xsd_dir.mkdir()
+        (xsd_dir / "anlageneegwind.xsd").write_text(MINIMAL_XSD)
+
+        result = read_mastr_table_descriptions_from_xsd(xsd_dir, ["wind"])
+        assert len(result) == 1
+        table = next(iter(result))
+        assert table.original_table_name == "Root"
+        assert table.instance_name == "Instance"
+        assert len(table.columns) == 2


### PR DESCRIPTION
See #760 

Idea is to allow both for xsd.zip and unzipped xsd to be parsed.

### PR-Assignee
- [ ] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CHANGELOG.md)
- [ ] 📙 Update the documentation

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
