### PR TITLE
fix(tests): pin units on np.datetime64 NaT values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 
 
   ### Changed
+  - Pin explicit units on bare `np.datetime64("NaT")` values in unit tests for NumPy 2.5 compatibility
+    [#784](https://github.com/OpenEnergyPlatform/open-MaStR/pull/784)
   - Fix race condition in parallel bulk XML import that resulted in silent data loss
     [#765](https://github.com/OpenEnergyPlatform/open-MaStR/pull/765)
   - Add support for reading XSD files from both zipped / unzipped documentation sources

--- a/tests/xml_download/test_utils_write_to_database.py
+++ b/tests/xml_download/test_utils_write_to_database.py
@@ -63,12 +63,12 @@ def test_cast_date_columns_to_string():
             "Registrierungsdatum": [
                 datetime(2024, 3, 11).date(),
                 datetime(1999, 2, 1).date(),
-                np.datetime64("nat"),
+                np.datetime64("NaT", "D"),
             ],
             "DatumLetzteAktualisierung": [
                 datetime(2022, 3, 22),
                 datetime(2020, 1, 2, 10, 12, 46),
-                np.datetime64("nat"),
+                np.datetime64("NaT", "s"),
             ],
         }
     )
@@ -291,12 +291,12 @@ def test_add_table_to_sqlite_database(
             "InstallierteLeistung": [1.0, 100.4],
             "AnlageBetriebsstatus": [None, None],
             "Registrierungsdatum": [datetime(2022, 2, 2), datetime(2024, 3, 20)],
-            "Meldedatum": [np.datetime64("NaT"), np.datetime64("NaT")],
+            "Meldedatum": [np.datetime64("NaT", "s"), np.datetime64("NaT", "s")],
             "DatumLetzteAktualisierung": [
                 datetime(2022, 12, 2, 10, 10, 10, 300),
                 datetime(2024, 10, 10),
             ],
-            "EegInbetriebnahmedatum": [np.datetime64("NaT"), np.datetime64("NaT")],
+            "EegInbetriebnahmedatum": [np.datetime64("NaT", "s"), np.datetime64("NaT", "s")],
             "VerknuepfteEinheit": [None, None],
             "AnlagenschluesselEeg": [None, None],
             "AusschreibungZuschlag": [True, False],
@@ -304,7 +304,7 @@ def test_add_table_to_sqlite_database(
             "AnlagenkennzifferAnlagenregister_nv": [None, None],
             "Netzbetreiberzuordnungen": ["test1", "test2"],
             "DatenQuelle": [None, None],
-            "DatumDownload": [np.datetime64("NaT"), np.datetime64("NaT")],
+            "DatumDownload": [np.datetime64("NaT", "s"), np.datetime64("NaT", "s")],
         }
     )
 


### PR DESCRIPTION
## Summary of the discussion

NumPy 2.5 deprecates unitless `np.datetime64("NaT")` / `np.datetime64("nat")` (see issue #781). Tests emit DeprecationWarning when run under newer NumPy.

This PR pins explicit units in the affected unit tests:
- Date column (`Registrierungsdatum`) -> `np.datetime64("NaT", "D")`
- DateTime columns (`DatumLetzteAktualisierung`, `Meldedatum`, `EegInbetriebnahmedatum`, `DatumDownload`) -> `np.datetime64("NaT", "s")`

## Type of change (CHANGELOG.md)

### Updated
- Pin explicit units on bare `np.datetime64("NaT")` values in tests [(#784)](https://github.com/OpenEnergyPlatform/open-MaStR/pull/784)

## Workflow checklist

### Automation
Closes #781

### PR-Assignee
- [x] Follow the workflow in CONTRIBUTING.md
- [x] Update the CHANGELOG.md
- [ ] Update the documentation

### Reviewer
- [ ] Follow the Reviewer Guidelines
- [ ] Provided feedback and show sufficient appreciation for the work done
