### PR TITLE
Fix table name lookup in interleave_files #789

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 
 
 ### Changed
+- Fix table name extraction in `interleave_files` to enable parallel worker interleaving and reduce SQLite lock contention
+  [#790](https://github.com/OpenEnergyPlatform/open-MaStR/pull/790)
 - Fix race condition in parallel bulk XML import that resulted in silent data loss
   [#765](https://github.com/OpenEnergyPlatform/open-MaStR/pull/765)
 - Add support for reading XSD files from both zipped / unzipped documentation sources

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -41,6 +41,9 @@ authors:
   - family-names: "Will"
     given-names: "Simon"
     alias: "@Simon-Will"
+  - family-names: "Rady"
+    given-names: "Hassan"
+    alias: "@hassanrady"
 identifiers:
   - type: swh
     value: 'swh:1:dir:28252b3ca57b56d22be851bad576b6748af2e171'

--- a/open_mastr/xml_download/utils_write_to_database.py
+++ b/open_mastr/xml_download/utils_write_to_database.py
@@ -271,7 +271,8 @@ def interleave_files(threads_data: list):
     files_grouped_by_table = {}
 
     for item in threads_data:
-        table_name = item[2]
+        db_table = item[1]
+        table_name = db_table.name
         if table_name not in files_grouped_by_table:
             files_grouped_by_table[table_name] = []
         files_grouped_by_table[table_name].append(item)

--- a/tests/xml_download/test_utils_write_to_database.py
+++ b/tests/xml_download/test_utils_write_to_database.py
@@ -9,7 +9,6 @@ import pytest
 from sqlalchemy import (
     Boolean,
     Column,
-    create_engine,
     Date,
     DateTime,
     Double,
@@ -18,22 +17,22 @@ from sqlalchemy import (
     MetaData,
     String,
     Table,
+    create_engine,
 )
-
 
 from open_mastr.utils.sqlalchemy_tables import CatalogString
 from open_mastr.xml_download.utils_write_to_database import (
     add_missing_columns_to_table,
+    add_table_to_non_sqlite_database,
+    add_table_to_sqlite_database,
     add_zero_as_first_character_for_too_short_string,
     cast_date_columns_to_string,
     correct_ordering_of_filelist,
     extract_xml_table_name,
+    interleave_files,
     is_date_column,
     process_table_before_insertion,
     read_xml_file,
-    add_table_to_non_sqlite_database,
-    add_table_to_sqlite_database,
-    interleave_files,
 )
 
 
@@ -213,17 +212,16 @@ def test_add_missing_columns_to_table(engine_testdb: Engine) -> None:
         Column("DatumLetzteAktualisierung", DateTime),
     )
     table.create(engine_testdb)
-    with engine_testdb.connect() as con:
-        with con.begin():
-            initial_data_in_db = pd.DataFrame(
-                {
-                    "EinheitMastrNummer": ["id1"],
-                    "DatumLetzteAktualisierung": [datetime(2022, 2, 2)],
-                }
-            )
-            initial_data_in_db.to_sql(
-                table.name, con=con, if_exists="append", index=False
-            )
+    with engine_testdb.connect() as con, con.begin():
+        initial_data_in_db = pd.DataFrame(
+            {
+                "EinheitMastrNummer": ["id1"],
+                "DatumLetzteAktualisierung": [datetime(2022, 2, 2)],
+            }
+        )
+        initial_data_in_db.to_sql(
+            table.name, con=con, if_exists="append", index=False
+        )
 
     add_missing_columns_to_table(engine_testdb, table, ["NewColumn"])
 
@@ -320,21 +318,26 @@ def test_add_table_to_sqlite_database(
 
 
 def test_interleave_files():
-    input_data = [
-        ("AnlagenEegBiomasse.xml", "anlageneegbiomasse", "anlageneegbiomasse"),
-        ("AnlagenEegSolar_1.xml", "anlageneegsolar", "anlageneegsolar"),
-        ("AnlagenEegSolar_2.xml", "anlageneegsolar", "anlageneegsolar"),
-        ("AnlagenEegWind_1.xml", "anlageneegwind", "anlageneegwind"),
-        ("AnlagenEegWind_2.xml", "anlageneegwind", "anlageneegwind"),
-        ("AnlagenEegWind_3.xml", "anlageneegwind", "anlageneegwind"),
-        ("Bilanzierungsgebiete.xml", "bilanzierungsgebiete", "bilanzierungsgebiete"),
+    from sqlalchemy import Column, Integer, MetaData, Table
+
+    meta = MetaData()
+    tbl_solar = Table("AnlagenEegSolar", meta, Column("id", Integer, primary_key=True))
+    tbl_wind = Table("AnlagenEegWind", meta, Column("id", Integer, primary_key=True))
+    tbl_bio = Table("AnlagenEegBiomasse", meta, Column("id", Integer, primary_key=True))
+
+    db_url = "sqlite:////home/user/.open-MaStR/data/sqlite/open-mastr.db"
+    prod_like_input = [
+        ("Solar_1.xml", tbl_solar, db_url, None),
+        ("Solar_2.xml", tbl_solar, db_url, None),
+        ("Wind_1.xml", tbl_wind, db_url, None),
+        ("Wind_2.xml", tbl_wind, db_url, None),
+        ("Bio_1.xml", tbl_bio, db_url, None),
     ]
-    assert interleave_files(input_data) == [
-        ("AnlagenEegBiomasse.xml", "anlageneegbiomasse", "anlageneegbiomasse"),
-        ("AnlagenEegSolar_1.xml", "anlageneegsolar", "anlageneegsolar"),
-        ("AnlagenEegWind_1.xml", "anlageneegwind", "anlageneegwind"),
-        ("Bilanzierungsgebiete.xml", "bilanzierungsgebiete", "bilanzierungsgebiete"),
-        ("AnlagenEegSolar_2.xml", "anlageneegsolar", "anlageneegsolar"),
-        ("AnlagenEegWind_2.xml", "anlageneegwind", "anlageneegwind"),
-        ("AnlagenEegWind_3.xml", "anlageneegwind", "anlageneegwind"),
+    interleaved_prod = interleave_files(prod_like_input)
+    assert interleaved_prod == [
+        ("Solar_1.xml", tbl_solar, db_url, None),
+        ("Wind_1.xml", tbl_wind, db_url, None),
+        ("Bio_1.xml", tbl_bio, db_url, None),
+        ("Solar_2.xml", tbl_solar, db_url, None),
+        ("Wind_2.xml", tbl_wind, db_url, None),
     ]


### PR DESCRIPTION
## Summary of the discussion

### Summary of Changes
- Fixed `interleave_files` to extract table name from `item[1]` (`Table` / string) instead of `item[2]` (database connection URL).
- Added comprehensive unit tests covering both string names and SQLAlchemy `Table` instances with realistic database URLs.
- Added author details to `CITATION.cff` and logged changes in `CHANGELOG.md`.





### Automation
Closes #789

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CHANGELOG.md)
- [x] 📙 Update the documentation

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
