### PR TITLE
Fix Mastr.to_csv treating a single table name string as an iterable of characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 
 
 ### Changed
+- Fix `Mastr.to_csv` iterating over a single table name string character by character instead of exporting the named table
+  [#795](https://github.com/OpenEnergyPlatform/open-MaStR/pull/795)
 - Fix table name extraction in `interleave_files` to enable parallel worker interleaving and reduce SQLite lock contention
   [#790](https://github.com/OpenEnergyPlatform/open-MaStR/pull/790)
 - Fix race condition in parallel bulk XML import that resulted in silent data loss

--- a/open_mastr/mastr.py
+++ b/open_mastr/mastr.py
@@ -415,16 +415,16 @@ class Mastr:
 
     def to_csv(
         self,
-        db_table_names: Iterable[str] = None,
+        db_table_names: Union[str, Iterable[str]] = None,
         chunksize: int = 500000,
     ) -> None:
         """Export tables from existing database to CSV.
 
         Parameters
         ----------
-        db_table_names : Iterable of str or None, optional
-            The names of the database tables to export. If None, all tables in the database will be
-            exported. Defaults to None.
+        db_table_names : str, Iterable of str, or None, optional
+            The names of the database tables to export. A single table name can be passed as a
+            plain string. If None, all tables in the database will be exported. Defaults to None.
 
         chunksize : int, optional
             Number of rows to retrieve from the database before dumping them to the CSV file.
@@ -437,6 +437,8 @@ class Mastr:
         existing_table_names = set(inspector.get_table_names())
         if db_table_names is None:
             db_table_names = existing_table_names
+        elif isinstance(db_table_names, str):
+            db_table_names = [db_table_names]
 
         log.info(
             f"Exporting the following database tables to CSV: {', '.join(db_table_names)}"

--- a/tests/test_mastr.py
+++ b/tests/test_mastr.py
@@ -12,6 +12,7 @@ import pytest
 import responses
 import pandas as pd
 from open_mastr.mastr import Mastr
+from open_mastr.utils.config import get_data_config
 from open_mastr.utils.constants import TABLE_TRANSLATIONS
 from open_mastr.utils.sqlalchemy_tables import CatalogString
 from .conftest import MOCKUP_XML_ZIP, NUMBER_ROWS_IN_MOCK_XML_FILES
@@ -20,6 +21,35 @@ from .conftest import MOCKUP_XML_ZIP, NUMBER_ROWS_IN_MOCK_XML_FILES
 def test_mastr_init(mastr: Mastr) -> None:
     assert os.path.exists(mastr._sqlite_folder_path)
     assert isinstance(mastr.engine, sqlalchemy.engine.Engine)
+
+
+def test_to_csv_single_table_name_as_string(
+    mastr: Mastr,
+    mockup_xml_zip_in_output_dir: Path,
+    mockup_docs_zip_in_output_dir: Path,
+) -> None:
+    mastr.download(data="wind")
+    mastr.to_csv(db_table_names="EinheitenWind")
+
+    data_path = Path(mastr.output_dir) / "data" / get_data_config()
+    csv_files = list(data_path.glob("*.csv"))
+    assert [f.name for f in csv_files] == ["EinheitenWind.csv"]
+
+    df = pd.read_csv(csv_files[0])
+    assert len(df) == NUMBER_ROWS_IN_MOCK_XML_FILES
+
+
+def test_to_csv_multiple_table_names_as_list(
+    mastr: Mastr,
+    mockup_xml_zip_in_output_dir: Path,
+    mockup_docs_zip_in_output_dir: Path,
+) -> None:
+    mastr.download(data="wind")
+    mastr.to_csv(db_table_names=["EinheitenWind"])
+
+    data_path = Path(mastr.output_dir) / "data" / get_data_config()
+    csv_files = list(data_path.glob("*.csv"))
+    assert [f.name for f in csv_files] == ["EinheitenWind.csv"]
 
 
 def test_download_wind(


### PR DESCRIPTION
## Summary of the discussion

`Mastr.to_csv(db_table_names=...)` is typed as `Iterable[str]`, so a plain string is a valid-looking argument. Because a `str` is itself iterable over its characters, passing a single table name (e.g. `db.to_csv(db_table_names="EinheitenWind")`) iterated `E, i, n, h, ...` instead of exporting the `EinheitenWind` table, and every one of those single-character "tables" was skipped with a warning.

Fixed by wrapping `db_table_names` in a one-element list when it is a `str`, and widened the type hint to `Union[str, Iterable[str]]` to reflect the accepted input.

## Type of change (CHANGELOG.md)

### Updated
- Fix `Mastr.to_csv` iterating over a single table name string character by character instead of exporting the named table [(#795)](https://github.com/OpenEnergyPlatform/open-MaStR/pull/795)

## Workflow checklist

### Automation
Closes #794

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CHANGELOG.md)
- [ ] 📙 Update the documentation

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done

## How this was tested

Added `test_to_csv_single_table_name_as_string` and `test_to_csv_multiple_table_names_as_list` to `tests/test_mastr.py`, reusing the existing `mastr` / mockup-XML fixtures. Confirmed the new single-string test fails on `develop` (iterates over characters, exports nothing) and passes with the fix. Ran the full `tests/test_mastr.py` suite locally: 25 passed.

