### PR TITLE
769: Add hard-coded catalog category columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 
 
 ### Changed
+- Translate catalog category IDs for fields that are missing XSD restrictions during bulk cleansing
+  [#769](https://github.com/OpenEnergyPlatform/open-MaStR/issues/769)
 - Fix `Mastr.to_csv` iterating over a single table name string character by character instead of exporting the named table
   [#795](https://github.com/OpenEnergyPlatform/open-MaStR/pull/795)
 - Fix table name extraction in `interleave_files` to enable parallel worker interleaving and reduce SQLite lock contention

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 
 ### Changed
 - Translate catalog category IDs for fields that are missing XSD restrictions during bulk cleansing
-  [#797](https://github.com/OpenEnergyPlatform/open-MaStR/pull/797)
+  [#796](https://github.com/OpenEnergyPlatform/open-MaStR/pull/796)
 - Fix `Mastr.to_csv` iterating over a single table name string character by character instead of exporting the named table
   [#795](https://github.com/OpenEnergyPlatform/open-MaStR/pull/795)
 - Fix table name extraction in `interleave_files` to enable parallel worker interleaving and reduce SQLite lock contention

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 
 ### Changed
 - Translate catalog category IDs for fields that are missing XSD restrictions during bulk cleansing
-  [#769](https://github.com/OpenEnergyPlatform/open-MaStR/issues/769)
+  [#797](https://github.com/OpenEnergyPlatform/open-MaStR/pull/797)
 - Fix `Mastr.to_csv` iterating over a single table name string character by character instead of exporting the named table
   [#795](https://github.com/OpenEnergyPlatform/open-MaStR/pull/795)
 - Fix table name extraction in `interleave_files` to enable parallel worker interleaving and reduce SQLite lock contention

--- a/open_mastr/utils/xsd_tables.py
+++ b/open_mastr/utils/xsd_tables.py
@@ -14,6 +14,15 @@ from open_mastr.utils.constants import COLUMN_TRANSLATIONS, TABLE_TRANSLATIONS
 
 _XML_SCHEMA_PREFIX = "{http://www.w3.org/2001/XMLSchema}"
 
+# Some catalog category fields are declared as unrestricted primitive types in
+# the MaStR XSDs, so they cannot be detected from the schema restrictions.
+CATALOG_COLUMNS_MISSING_XSD_RESTRICTION = {
+    "Netze": frozenset({"Marktgebiet", "Bundesland", "Sparte"}),
+    "EinheitenWind": frozenset({"Hersteller"}),
+    "EinheitenVerbrennung": frozenset({"WeitereBrennstoffe"}),
+    "Marktakteure": frozenset({"Rechtsform", "Registergericht"}),
+}
+
 log = logging.getLogger("open-MaStR")
 
 
@@ -105,14 +114,21 @@ class MastrColumnDescription:
 
     @classmethod
     def from_xsd_element(
-        cls, xsd_element: xmlschema.XsdElement
+        cls, xsd_element: xmlschema.XsdElement, original_table_name: str
     ) -> "MastrColumnDescription":
         normalized_name = normalize_mastr_name(xsd_element.name)
         return cls(
             original_name=xsd_element.name,
             normalized_name=normalized_name,
             english_name=translate_mastr_column_name(normalized_name),
-            type=MastrColumnType.from_xsd_type(xsd_element.type),
+            type=(
+                MastrColumnType.CATALOG_VALUE
+                if normalized_name
+                in CATALOG_COLUMNS_MISSING_XSD_RESTRICTION.get(
+                    original_table_name, frozenset()
+                )
+                else MastrColumnType.from_xsd_type(xsd_element.type)
+            ),
         )
 
 
@@ -138,16 +154,15 @@ class MastrTableDescription:
         except (AttributeError, IndexError, TypeError) as e:
             raise ValueError(f"Could not find columns in XML schema {schema!r}") from e
 
-        columns = tuple(
-            MastrColumnDescription.from_xsd_element(element)
-            for element in column_elements
-        )
-
         # We don't normalize the table name because
         # - it would introduce too much complexity to have two German table names
         # - the normalization would leave the table name as is (at least as of Feb 2026)
         original_table_name = root.name
         english_table_name = translate_mastr_table_name(original_table_name)
+        columns = tuple(
+            MastrColumnDescription.from_xsd_element(element, original_table_name)
+            for element in column_elements
+        )
 
         return cls(
             original_table_name=original_table_name,

--- a/open_mastr/xml_download/utils_cleansing_bulk.py
+++ b/open_mastr/xml_download/utils_cleansing_bulk.py
@@ -47,10 +47,13 @@ def replace_mastr_katalogeintraege(
     katalogwerte = create_katalogwerte_from_bulk_download(zipped_xml_file_path)
     for column_name in df.columns:
         if column_name in catalog_columns:
-            if pd.api.types.is_string_dtype(df[column_name]):
+            if (
+                pd.api.types.is_string_dtype(df[column_name])
+                or pd.api.types.is_object_dtype(df[column_name])
+            ):
                 # Handle comma seperated strings from catalog values
                 df[column_name] = (
-                    df[column_name]
+                    df[column_name].astype("string")
                     .str.split(",", expand=True)
                     .apply(lambda x: x.str.strip())
                     .replace("", None)

--- a/open_mastr/xml_download/utils_cleansing_bulk.py
+++ b/open_mastr/xml_download/utils_cleansing_bulk.py
@@ -47,13 +47,15 @@ def replace_mastr_katalogeintraege(
     katalogwerte = create_katalogwerte_from_bulk_download(zipped_xml_file_path)
     for column_name in df.columns:
         if column_name in catalog_columns:
-            if (
-                pd.api.types.is_string_dtype(df[column_name])
-                or pd.api.types.is_object_dtype(df[column_name])
-            ):
-                # Handle comma seperated strings from catalog values
-                df[column_name] = (
-                    df[column_name].astype("string")
+            if pd.api.types.is_string_dtype(
+                df[column_name]
+            ) or pd.api.types.is_object_dtype(df[column_name]):
+                # Only replace rows that still are numeric catalog IDs;
+                # already-resolved names (e.g. "Bayern") pass through unchanged.
+                is_id = df[column_name].astype("string").str.match(r"^[\d,\s]+$")
+                df.loc[is_id, column_name] = (
+                    df.astype("string")
+                    .loc[is_id, column_name]
                     .str.split(",", expand=True)
                     .apply(lambda x: x.str.strip())
                     .replace("", None)

--- a/open_mastr/xml_download/utils_cleansing_bulk.py
+++ b/open_mastr/xml_download/utils_cleansing_bulk.py
@@ -52,10 +52,10 @@ def replace_mastr_katalogeintraege(
             ) or pd.api.types.is_object_dtype(df[column_name]):
                 # Only replace rows that still are numeric catalog IDs;
                 # already-resolved names (e.g. "Bayern") pass through unchanged.
-                is_id = df[column_name].astype("string").str.match(r"^[\d,\s]+$")
+                column_as_string = df[column_name].astype("string")
+                is_id = column_as_string.str.match(r"^[\d,\s]+$")
                 df.loc[is_id, column_name] = (
-                    df.astype("string")
-                    .loc[is_id, column_name]
+                    column_as_string.loc[is_id]
                     .str.split(",", expand=True)
                     .apply(lambda x: x.str.strip())
                     .replace("", None)

--- a/tests/test_mastr.py
+++ b/tests/test_mastr.py
@@ -421,6 +421,19 @@ def test_mastr_generate_data_model(
     assert isinstance(
         changed_dso_assignment_table.c.OpenMastrId.type, sqlalchemy.Integer
     )
+    grids_table = mastr_table_to_db_table["Netze"]
+    assert isinstance(grids_table.c.Marktgebiet.type, CatalogString)
+    assert isinstance(grids_table.c.Bundesland.type, CatalogString)
+    assert isinstance(grids_table.c.Sparte.type, CatalogString)
+    assert isinstance(
+        mastr_table_to_db_table["EinheitenWind"].c.Hersteller.type, CatalogString
+    )
+    assert isinstance(
+        mastr_table_to_db_table["Marktakteure"].c.Rechtsform.type, CatalogString
+    )
+    assert isinstance(
+        mastr_table_to_db_table["Marktakteure"].c.Registergericht.type, CatalogString
+    )
 
 
 def test_mastr_generate_data_model_english(
@@ -460,6 +473,8 @@ def test_mastr_generate_data_model_english(
     assert isinstance(
         changed_dso_assignment_table.c.OpenMastrId.type, sqlalchemy.Integer
     )
+    grids_table = mastr_table_to_db_table["Netze"]
+    assert isinstance(grids_table.c.marketArea.type, CatalogString)
 
 
 def test_mastr_generate_data_model_fallback_to_included_docs(

--- a/tests/test_xsd_tables.py
+++ b/tests/test_xsd_tables.py
@@ -3,9 +3,12 @@ import zipfile
 from pathlib import Path
 
 from open_mastr.utils.xsd_tables import (
+    MastrColumnType,
     read_mastr_table_descriptions_from_xsd,
     _iterate_xsd_files,
 )
+from open_mastr.mastr import _get_fallback_xsd
+
 
 MINIMAL_XSD = """<?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
@@ -74,3 +77,39 @@ def test_read_mastr_table_descriptions_from_xsd():
         assert table.original_table_name == "Root"
         assert table.instance_name == "Instance"
         assert len(table.columns) == 2
+
+
+def test_catalog_columns_missing_xsd_restriction_are_catalog_values():
+    fallback_xsd_dir = _get_fallback_xsd()
+    table_descriptions = read_mastr_table_descriptions_from_xsd(
+        fallback_xsd_dir, ["combustion", "grid", "market", "wind"]
+    )
+    table_to_column_types = {
+        table.original_table_name: {
+            column.normalized_name: column.type for column in table.columns
+        }
+        for table in table_descriptions
+    }
+
+    assert {
+        "Marktgebiet": MastrColumnType.CATALOG_VALUE,
+        "Bundesland": MastrColumnType.CATALOG_VALUE,
+        "Sparte": MastrColumnType.CATALOG_VALUE,
+    }.items() <= table_to_column_types["Netze"].items()
+    assert (
+        table_to_column_types["EinheitenVerbrennung"]["WeitereBrennstoffe"]
+        is MastrColumnType.CATALOG_VALUE
+    )
+    assert (
+        table_to_column_types["EinheitenWind"]["Hersteller"]
+        is MastrColumnType.CATALOG_VALUE
+    )
+    assert (
+        table_to_column_types["Marktakteure"]["Rechtsform"]
+        is MastrColumnType.CATALOG_VALUE
+    )
+    assert (
+        table_to_column_types["Marktakteure"]["Registergericht"]
+        is MastrColumnType.CATALOG_VALUE
+    )
+    assert table_to_column_types["Netze"]["Bezeichnung"] is MastrColumnType.STRING

--- a/tests/xml_download/test_utils_cleansing_bulk.py
+++ b/tests/xml_download/test_utils_cleansing_bulk.py
@@ -1,5 +1,6 @@
-import pandas as pd
 from pathlib import Path
+
+import pandas as pd
 
 from open_mastr.xml_download.utils_cleansing_bulk import (
     cleanse_bulk_data,
@@ -63,6 +64,29 @@ def test_replace_mastr_katalogeintraege_with_comma_separated_ids(
             catalog_columns={"Bundesland"},
         ),
         df_replaced,
+        # Only the values matter here, not whether the string column ends up as
+        # object or as a string dtype.
+        check_dtype=False,
+    )
+
+
+def test_replace_mastr_katalogeintraege_keeps_already_resolved_names(
+    mockup_xml_zip_in_output_dir: Path,
+) -> None:
+    # Values that are already resolved catalog names must pass through unchanged,
+    # while numeric IDs (single or comma-separated) are still replaced.
+    df_raw = pd.DataFrame({"Bundesland": ["Bayern", 335, "335, 336"]})
+    df_replaced = pd.DataFrame({"Bundesland": ["Bayern", "Bayern", "Bayern,Bremen"]})
+
+    df_new = replace_mastr_katalogeintraege(
+        zipped_xml_file_path=str(mockup_xml_zip_in_output_dir),
+        df=df_raw,
+        catalog_columns={"Bundesland"},
+    )
+    pd.testing.assert_frame_equal(
+        df_new,
+        df_replaced,
+        check_dtype=False,
     )
 
 

--- a/tests/xml_download/test_utils_cleansing_bulk.py
+++ b/tests/xml_download/test_utils_cleansing_bulk.py
@@ -1,5 +1,4 @@
 import pandas as pd
-import pytest
 from pathlib import Path
 
 from open_mastr.xml_download.utils_cleansing_bulk import (
@@ -46,6 +45,22 @@ def test_replace_mastr_katalogeintraege(mockup_xml_zip_in_output_dir: Path) -> N
             zipped_xml_file_path=str(mockup_xml_zip_in_output_dir),
             df=df_raw,
             catalog_columns={"Bundesland", "Einheittyp"},
+        ),
+        df_replaced,
+    )
+
+
+def test_replace_mastr_katalogeintraege_with_comma_separated_ids(
+    mockup_xml_zip_in_output_dir: Path,
+) -> None:
+    df_raw = pd.DataFrame({"Bundesland": [335, "335, 336"]})
+    df_replaced = pd.DataFrame({"Bundesland": ["Bayern", "Bayern,Bremen"]})
+
+    pd.testing.assert_frame_equal(
+        replace_mastr_katalogeintraege(
+            zipped_xml_file_path=str(mockup_xml_zip_in_output_dir),
+            df=df_raw,
+            catalog_columns={"Bundesland"},
         ),
         df_replaced,
     )


### PR DESCRIPTION
## Summary of the discussion

`bulk_cleansing=True` identifies MaStR catalog category fields from XSD enumeration restrictions. Some known category fields are declared as primitive types or unrestricted restrictions in the XSD, leaving their numeric IDs untranslated.

I'm adding an explicit table-scoped list of those XSD exceptions and classify them as catalog values during model generation. The existing bulk cleansing flow then replaces their IDs with values from `Katalogwerte.xml`.

In my pandas version, mixed columns of ints and comma-separated strings are inferred by pandas as `object`, not `string`. To correctly handle these columns, I modified the dtype check to also do the splitting of values for `object` columns. There's a regression test for that, too.

## Type of change (CHANGELOG.md)

### Changed
- Translate catalog category IDs for fields that are missing XSD restrictions during bulk cleansing
  [#769](https://github.com/OpenEnergyPlatform/open-MaStR/issues/769)

## Workflow checklist

### Automation
Closes #769

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CHANGELOG.md)
- [ ] 📙 Update the documentation
  - Not applicable imo

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done