### PR TITLE
Include AnlagenStromSpeicher in "storage"; deprecate "storage_units" (#762)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 
 
 ### Changed
+- Include AnlagenStromSpeicher in `storage` and deprecate `storage_units`
+  [#799](https://github.com/OpenEnergyPlatform/open-MaStR/pull/799)
 - Translate catalog category IDs for fields that are missing XSD restrictions during bulk cleansing
   [#796](https://github.com/OpenEnergyPlatform/open-MaStR/pull/796)
 - Fix `Mastr.to_csv` iterating over a single table name string character by character instead of exporting the named table

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and the versioning aims to respect [Semantic Versioning](http://semver.org/spec/
 
 
 ### Changed
-- Include AnlagenStromSpeicher in `storage` and deprecate `storage_units`
+- Include AnlagenStromSpeicher when passing argument "storage" to `Mastr.download` and deprecate "storage_units"
   [#799](https://github.com/OpenEnergyPlatform/open-MaStR/pull/799)
 - Translate catalog category IDs for fields that are missing XSD restrictions during bulk cleansing
   [#796](https://github.com/OpenEnergyPlatform/open-MaStR/pull/796)

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -201,6 +201,33 @@ previously created SQLite database tables.
 If only some specific tables are of interest, they can be specified with the parameter `data`. Every table that is
 selected in `data` will be deleted from the local database, if existent, and then filled with data from the xml files.
 
+### `data` table mapping
+
+The `data` parameter accepts the following values. Each value includes the listed MaStR XML tables in the bulk
+download.
+
+| `data` value | Included MaStR tables |
+|---|---|
+| `wind` | `AnlagenEegWind`, `EinheitenWind` |
+| `solar` | `AnlagenEegSolar`, `EinheitenSolar` |
+| `biomass` | `AnlagenEegBiomasse`, `EinheitenBiomasse` |
+| `hydro` | `AnlagenEegWasser`, `EinheitenWasser` |
+| `gsgk` | `AnlagenEegGeothermieGrubengasDruckentspannung`, `EinheitenGeothermieGrubengasDruckentspannung` |
+| `combustion` | `AnlagenKwk`, `EinheitenVerbrennung` |
+| `nuclear` | `EinheitenKernkraft` |
+| `gas` | `AnlagenGasSpeicher`, `EinheitenGasErzeuger`, `EinheitenGasSpeicher`, `EinheitenGasverbraucher` |
+| `storage` | `AnlagenEegSpeicher`, `EinheitenStromSpeicher`, `AnlagenStromSpeicher` |
+| `electricity_consumer` | `EinheitenStromVerbraucher` |
+| `location` | `Lokationen` |
+| `market` | `Marktakteure`, `MarktakteureUndRollen` |
+| `grid` | `Netzanschlusspunkte`, `Netze` |
+| `balancing_area` | `Bilanzierungsgebiete` |
+| `permit` | `EinheitenGenehmigung` |
+| `deleted_units` | `GeloeschteUndDeaktivierteEinheiten` |
+| `deleted_market_actors` | `GeloeschteUndDeaktivierteMarktakteure` |
+| `retrofit_units` | `Ertuechtigungen` |
+| `changed_dso_assignment` | `EinheitenAenderungNetzbetreiberzuordnungen` |
+
 In the next step, a basic data cleansing is performed. Many entries in the MaStR from the bulk download are replaced by numbers.
 As an example, instead of writing the German states where the unit is registered (Saxony, Brandenburg, Bavaria, ...) the MaStR states 
 corresponding digits (7, 2, 9, ...). One major step of cleansing is therefore to replace those digits with their original meaning. 
@@ -471,6 +498,4 @@ For API calls, models and optional parameters refer to the
 
 !!! warning "MaStRMirror has been removed"
     In versions > `v0.16.0` the `MaStRMirror` class cannot be used anymore.
-
-
 

--- a/open_mastr/utils/constants.py
+++ b/open_mastr/utils/constants.py
@@ -77,7 +77,7 @@ BULK_INCLUDE_TABLES_MAP = {
     ],
     "combustion": ["anlagenkwk", "einheitenverbrennung"],
     "nuclear": ["einheitenkernkraft"],
-    "storage": ["anlageneegspeicher", "einheitenstromspeicher"],
+    "storage": ["anlageneegspeicher", "einheitenstromspeicher", "anlagenstromspeicher"],
     "storage_units": ["anlagenstromspeicher"],
     "gas": [
         "anlagengasspeicher",

--- a/open_mastr/utils/helpers.py
+++ b/open_mastr/utils/helpers.py
@@ -193,6 +193,12 @@ def data_to_include_tables(data: list[str]) -> set[str]:
     set
         Set of file names
     """
+    if "storage_units" in data:
+        log.warning(
+            "The data parameter 'storage_units' is deprecated and will be removed in the future."
+            " Please use 'storage' instead, which now also includes AnlagenStromSpeicher."
+        )
+
     # Map data selection to include tables in xml
     include_tables = {
         table for tech in data for table in BULK_INCLUDE_TABLES_MAP[tech]


### PR DESCRIPTION
## Summary of the discussion

As described in #762, we currently map the term "storage" to EinheitenStromSpeicher & AnlagenEegSpeicher, and the term "storage_units" to AnlagenStromSpeicher. This is confusing; and users who want to download information about EinheitenStromSpeicher , probably also want to have information about AnlagenStromSpeicher.

We therefore decided to include AnlagenStromSpeicher in "storage" and to deprecate "storage_units".

## Type of change (CHANGELOG.md)

### Updated
- Include AnlagenStromSpeicher in `storage` and deprecate `storage_units` [#799](https://github.com/OpenEnergyPlatform/open-MaStR/pull/799)

## Workflow checklist

### Automation
Closes #762

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CHANGELOG.md)
- [x] 📙 Update the documentation

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/OpenEnergyPlatform/open-MaStR/blob/production/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done